### PR TITLE
First round of feedback

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -51,13 +51,6 @@ sealed trait LagomApp extends App {
     // fullClasspath contains the Lagom services, Lagom framework and all its dependencies
 
     super.projectSettings ++ Vector(
-      /*
-      libraryDependencies ++= (
-        for {
-          module <- magic.Lagom.component("api-tools").toSeq
-        } yield module % apiTools
-      ),*/
-
       managedClasspath in apiTools :=
         Classpaths.managedJars(apiTools, (classpathTypes in apiTools).value, update.value),
 

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -30,7 +30,7 @@ object SbtReactiveApp {
              healthCheck: Option[Check],
              readinessCheck: Option[Check],
              environmentVariables: Map[String, EnvironmentVariable]): Map[String, String] = {
-    def ns(key: String*) = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
+    def ns(key: String*): String = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
 
     val keyValuePairs =
       diskSpace

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/package.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/package.scala
@@ -26,12 +26,12 @@ package object magic {
       val clazz = classLoader.loadClass(className)
       val t = implicitly[ClassTag[T]].runtimeClass
       clazz.getField("MODULE$").get(null) match {
-        case null                  => throw new NullPointerException
+        case null                  => throw new ClassNotFoundException(s"Unable to find $className using classloader: $classLoader")
         case c if !t.isInstance(c) => throw new ClassCastException(s"${clazz.getName} is not a subtype of $t")
         case c: T                  => c
       }
-    } recover {
-      case i: InvocationTargetException if i.getTargetException ne null => throw i.getTargetException
+    }.recover {
+      case i: InvocationTargetException if i.getTargetException != null => throw i.getTargetException
     }
 
   def objectExists(classLoader: ClassLoader, className: String): Boolean =


### PR DESCRIPTION
@longshorej - nice work setting up `sbt-reactive-app`, and nice work re the Lagom endpoint detection!

I'll see if I can setup the `scripted` test for all the possible combinations of apps we're trying to support.

Also we haven't handled the Akka remoting endpoint - perhaps we'll need a separate setting for enabling Akka remoting endpoint. If Lagom app is detected with any of these Lagom module -
 cluster, sharding, or persistence - we can enable the setting for Akka remoting endpoint.
