### PR TITLE
Implement startup script

### DIFF
--- a/src/main/resources/rp-start
+++ b/src/main/resources/rp-start
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec "$@"

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -40,4 +40,6 @@ trait SbtReactiveAppKeys {
   val reactiveLibProject = SettingKey[Option[String]]("rp-reactive-lib-project")
 
   val reactiveLibVersion = SettingKey[Option[String]]("rp-reactive-lib-version")
+
+  val startScriptLocation = SettingKey[Option[String]]("rp-start-script")
 }

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -18,8 +18,11 @@ readinessCheck := Some(HttpCheck(1234, 60, "/healthz"))
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
+  val targetDir = target.value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
+    s"""ADD ${targetDir / "rp-start"} /rp-start""",
+    """ENTRYPOINT ["/rp-start", "bin/labels"]""",
     """LABEL com.lightbend.rp.app-name="labels"""",
     """LABEL com.lightbend.rp.disk-space="32768"""",
     """LABEL com.lightbend.rp.endpoints.0.acls.0.expression="^/test.*$"""",

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
@@ -1,0 +1,18 @@
+name := "start-script-disabled"
+
+enablePlugins(DockerPlugin)
+
+startScriptLocation := None
+
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """ENTRYPOINT ["bin/start-script-disabled"]""")
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(s"""Dockerfile is missing line "$line"""")
+    }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/test
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
@@ -1,0 +1,18 @@
+name := "start-script-enabled"
+
+enablePlugins(DockerPlugin)
+
+startScriptLocation := Some("/my-rp-entry")
+
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """ENTRYPOINT ["/my-rp-entry", "bin/start-script-enabled"]""")
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(s"""Dockerfile is missing line "$line"""")
+    }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/test
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check


### PR DESCRIPTION
This PR modifies the plugin to ensure a startup script is added to the container (to `/rp-start` by default).

The script itself doesn't do anything right now other than exec its arguments but it will be built into a shim to smooth out differences between target platforms.