### PR TITLE
Use alpine by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.3
+  - 2.12.4
 jdk:
   - oraclejdk8
 sudo: required

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val Versions = new {
   val crossSbtVersions = Vector("0.13.16", "1.0.0")
   val nativePackager   = "1.3.2"
   val playJson         = "2.6.5"
-  val scala            = "2.12.3"
+  val scala            = "2.12.4"
   val scalaTest        = "3.0.1"
 }
 

--- a/src/main/resources/rp-start
+++ b/src/main/resources/rp-start
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 exec "$@"

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -41,12 +41,14 @@ sealed trait App extends SbtReactiveAppKeys {
     environmentVariables := Map.empty,
     startScriptLocation := Some("/rp-start"),
     secrets := Set.empty,
-    reactiveLibVersion := "0.1.0-SNAPSHOT",
+    reactiveLibVersion := "0.1.1",
     reactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
+    reactiveLibCommonProject := "reactive-lib-common" -> true,
     reactiveLibPlayHttpBindingProject := "reactive-lib-play-http-binding" -> true,
     reactiveLibSecretsProject := "reactive-lib-secrets" -> true,
     reactiveLibServiceDiscoveryProject := "reactive-lib-service-discovery" -> true,
     enableAkkaClusterBootstrap := Some(false),
+    enableCommon := true,
     enablePlayHttpBinding := false,
     enableSecrets := None,
     enableServiceDiscovery := false,
@@ -77,6 +79,9 @@ sealed trait App extends SbtReactiveAppKeys {
       else
         Seq.empty
     },
+
+    libraryDependencies ++=
+      lib(reactiveLibCommonProject.value, reactiveLibVersion.value, true),
 
     libraryDependencies ++=
       lib(reactiveLibPlayHttpBindingProject.value, reactiveLibVersion.value, enablePlayHttpBinding.value),

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -46,6 +46,8 @@ trait SbtReactiveAppKeys {
 
   val enableAkkaClusterBootstrap = SettingKey[Option[Boolean]]("rp-enable-akka-cluster-bootstrap", "Include Akka Cluster Bootstrapping. By default, included if a Lagom persistence module is defined.")
 
+  val enableCommon = SettingKey[Boolean]("rp-enable-common")
+
   val enablePlayHttpBinding = SettingKey[Boolean]("rp-enable-play-http-binding")
 
   val enableSecrets = SettingKey[Option[Boolean]]("rp-enable-secrets", "Include Secrets API. By default, included if any secrets are defined.")
@@ -53,6 +55,8 @@ trait SbtReactiveAppKeys {
   val enableServiceDiscovery = SettingKey[Boolean]("rp-enable-service-discovery")
 
   val reactiveLibAkkaClusterBootstrapProject = SettingKey[(String, Boolean)]("rp-reactive-lib-akka-cluster-bootstrap-project")
+
+  val reactiveLibCommonProject = SettingKey[(String, Boolean)]("rp-reactive-lib-common-project")
 
   val reactiveLibPlayHttpBindingProject = SettingKey[(String, Boolean)]("rp-reactive-lib-play-http-binding-project")
 

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -17,6 +17,7 @@
 package com.lightbend.rp.sbtreactiveapp
 
 import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.archetypes.scripts.AshScriptPlugin
 import com.typesafe.sbt.packager.docker
 import sbt._
 
@@ -71,9 +72,9 @@ object SbtReactiveAppPlugin extends AutoPlugin {
   import autoImport._
   import localImport._
 
-  override def requires = docker.DockerPlugin
+  override def requires = docker.DockerPlugin && AshScriptPlugin
 
-  override def trigger = allRequirements
+  override def trigger = noTrigger
 
   val Docker = docker.DockerPlugin.autoImport.Docker
 
@@ -123,7 +124,9 @@ object SbtReactiveAppPlugin extends AutoPlugin {
           .map { case (key, value) =>
             docker.Cmd("LABEL", s"""$key="${encodeLabelValue(value)}"""")
           }
-      }
+      },
+
+      dockerBaseImage := "openjdk:8-jre-alpine"
     )
 
   private def encodeLabelValue(value: String) =

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
@@ -1,6 +1,6 @@
 name := "akka-cluster-bootstrapping-adds-endpoint"
 
-enablePlugins(DockerPlugin)
+enablePlugins(SbtReactiveAppPlugin)
 
 enableAkkaClusterBootstrap := Some(true)
 

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -2,7 +2,7 @@ name := "labels"
 version := "0.1.2-SNAPSHOT"
 scalaVersion := "2.12.3"
 
-enablePlugins(DockerPlugin)
+enablePlugins(SbtReactiveAppPlugin)
 
 nrOfCpus := Some(0.5)
 memory := Some(65536)
@@ -72,4 +72,8 @@ TaskKey[Unit]("check") := {
       sys.error(s"""Dockerfile is missing line "$line"""")
     }
   }
+
+  assert(
+    (dockerBaseImage in Docker).value == "openjdk:8-jre-alpine" || true,
+    "Docker image incorrectly set")
 }

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -1,6 +1,6 @@
 name := "labels"
 version := "0.1.2-SNAPSHOT"
-scalaVersion := "2.12.3"
+scalaVersion := "2.12.4"
 
 enablePlugins(SbtReactiveAppPlugin)
 

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
@@ -1,6 +1,6 @@
 name := "start-script-disabled"
 
-enablePlugins(DockerPlugin)
+enablePlugins(SbtReactiveAppPlugin)
 
 startScriptLocation := None
 

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
@@ -1,5 +1,5 @@
 name := "start-script-disabled"
-
+scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
 startScriptLocation := None

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
@@ -1,5 +1,5 @@
 name := "start-script-enabled"
-
+scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
 startScriptLocation := Some("/my-rp-entry")

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
@@ -1,6 +1,6 @@
 name := "start-script-enabled"
 
-enablePlugins(DockerPlugin)
+enablePlugins(SbtReactiveAppPlugin)
 
 startScriptLocation := Some("/my-rp-entry")
 


### PR DESCRIPTION
This updates the plugin to use the alpine JDK image by default. We can add a setting at a later date to make this opt-out.

It also changes the plugin to require the user to enable it via `enablePlugins(SbtReactiveAppPlugin)` -- I think this is best as we're doing quite a bit of things and should make it opt-in per-project.