### PR TITLE
Hack around broken script in native packager

### DIFF
--- a/src/main/resources/rp-start
+++ b/src/main/resources/rp-start
@@ -1,3 +1,24 @@
 #!/usr/bin/env sh
 
+# This script can be used to normalize environments at runtime, e.g.
+# shift variables around on Kubernetes/Marathon. It's executed inside
+# the Docker container.
+
+set -e
+
+# @TODO FIXME when upstream fixes this, see https://github.com/sbt/sbt-native-packager/issues/978
+# Hack around a bug in sbt-native-packager causing args
+# to not work when Ash Scripting is enabled
+
+if [ -d "$PWD/bin" ]; then
+  cat <<EOT >> "$PWD/bin/is_cygwin"
+#!/usr/bin/env sh
+exit 1
+EOT
+
+  chmod +x "$PWD/bin/is_cygwin"
+
+  export PATH="$PWD/bin:$PATH"
+fi
+
 exec "$@"


### PR DESCRIPTION
The script generated by native packager is broken - https://github.com/sbt/sbt-native-packager/issues/978

It results in this (note is_cygwin):

```
docker run -p 9000:9000 --env "JAVA_OPTS=-Dtesting=123" --env APPLICATION_SECRET=hey front-end:1.0.1-SNAPSHOT 
bin/front-end: line 56: is_cygwin: not found
```

With this fix, it results in this:

```
~/work/lightbend/activator-lagom-java-chirper#tooling $ docker run --env "JAVA_OPTS=-Dtesting=123" --env APPLICATION_SECRET=hey front-end:1.0.0-SNAPSHOT 
2017-11-18T01:42:34.883Z [info] akka.event.slf4j.Slf4jLogger [] - Slf4jLogger started
2017-11-18T01:42:35.559Z [info] org.hibernate.validator.internal.util.Version [] - HV000001: Hibernate Validator 5.2.4.Final
2017-11-18T01:42:35.630Z [info] play.api.Play [] - Application started (Prod)
2017-11-18T01:42:35.760Z [info] play.core.server.NettyServer [] - Listening for HTTP on /0.0.0.0:9000
```

This is because the script contains the following, and `is_cygwin` doesn't exist. This PR ensures our `rp-start` script (which exists for situations like this) can create a script that'll fix this behavior.

```
addJava "-Duser.dir=$(realpath "$(cd "${app_home}/.."; pwd -P)"  $(is_cygwin && echo "fix"))"
```