### PR TITLE
Only push when Docker plugin enabled and registry defined

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/package.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp
+
+import sbt.TaskKey
+
+package object sbtreactiveapp {
+  private[rp] val rpDockerPublish = TaskKey[Unit]("rp-docker-publish")
+}


### PR DESCRIPTION
This redefines the `publish in Docker` task to only publish for tasks that enable the `Docker` plugin and define a registry.

This leads to a much better experience for lagom projects where users will have the api projects and running `docker:publish` would lead to many error messages for them, as it would be falling back to the default `publish` implementation for the API projects which is likely to fail.