### PR TITLE
Fix Lagom service detection

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -105,8 +105,12 @@ sealed trait LagomApp extends App {
       enablePlayHttpBinding := true,
       enableAkkaClusterBootstrap := None,
 
+      ivyConfigurations += apiTools,
+
       managedClasspath in apiTools :=
         Classpaths.managedJars(apiTools, (classpathTypes in apiTools).value, update.value),
+
+      libraryDependencies ++= magic.Lagom.component("api-tools").toVector.map(_ % apiTools),
 
       endpoints := endpoints.value ++ magic.Lagom.endpoints(
         ((managedClasspath in apiTools).value ++ (fullClasspath in Compile).value).toVector,


### PR DESCRIPTION
This fixes a bug in Lagom service detection -- undiscovered before because manual tests were done in a project with `sbt-conductr`. Upon removing `sbt-conductr`, services would no longer be detected. This fixes that.