### PR TITLE
Add labels for app type and the modules enabled/disabled

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -30,8 +30,11 @@ sealed trait App extends SbtReactiveAppKeys {
     else
       Seq.empty
 
+  def applicationType: String
+
   def projectSettings: Seq[Setting[_]] = Vector(
     namespace := None,
+    appType := applicationType,
     nrOfCpus := None,
     diskSpace := None,
     memory := None,
@@ -100,6 +103,8 @@ sealed trait App extends SbtReactiveAppKeys {
 }
 
 sealed trait LagomApp extends App {
+  val applicationType: String = "lagom"
+
   val apiTools = config("api-tools").hide
 
   override def projectSettings: Seq[Setting[_]] = {
@@ -186,6 +191,8 @@ case object LagomPlayScalaApp extends LagomApp {
 }
 
 case object PlayApp extends App {
+  val applicationType: String = "play"
+
   override def projectSettings: Seq[Setting[_]] = {
     super.projectSettings ++ Vector(
       // Note: Play & Lagom need their endpoints defined first (see play-http-binding)
@@ -198,7 +205,9 @@ case object PlayApp extends App {
   }
 }
 
-case object BasicApp extends App
+case object BasicApp extends App {
+  val applicationType: String = "basic"
+}
 
 object App {
   def apply: App =

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/Endpoint.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/Endpoint.scala
@@ -22,10 +22,14 @@ sealed trait Endpoint {
   def name: String
   def port: Int
   def protocol: String
+
+  def withName(s: String): Endpoint
 }
 
 case class HttpEndpoint(name: String, port: Int, ingress: Seq[HttpIngress]) extends Endpoint {
   val protocol: String = "http"
+
+  def withName(n: String): Endpoint = copy(name = n)
 }
 
 object HttpEndpoint {
@@ -37,6 +41,8 @@ object HttpEndpoint {
 
 case class TcpEndpoint(name: String, port: Int, ingress: Option[PortIngress]) extends Endpoint {
   val protocol: String = "tcp"
+
+  def withName(n: String): Endpoint = copy(name = n)
 }
 
 object TcpEndpoint {
@@ -48,6 +54,8 @@ object TcpEndpoint {
 
 case class UdpEndpoint(name: String, port: Int, ingress: Option[PortIngress]) extends Endpoint {
   val protocol: String = "udp"
+
+  def withName(n: String): Endpoint = copy(name = n)
 }
 
 object UdpEndpoint {

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -23,6 +23,7 @@ object SbtReactiveApp {
   def labels(
     namespace: Option[String],
     appName: Option[String],
+    appType: Option[String],
     diskSpace: Option[Long],
     memory: Option[Long],
     nrOfCpus: Option[Double],
@@ -33,7 +34,8 @@ object SbtReactiveApp {
     readinessCheck: Option[Check],
     environmentVariables: Map[String, EnvironmentVariable],
     version: Option[(Int, Int, Int, Option[String])],
-    secrets: Set[Secret]): Map[String, String] = {
+    secrets: Set[Secret],
+    modules: Seq[(String, Boolean)]): Map[String, String] = {
     def ns(key: String*): String = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
 
     val keyValuePairs =
@@ -43,6 +45,11 @@ object SbtReactiveApp {
         appName
         .map(ns("app-name") -> _.toString)
         .toSeq ++
+        appType
+        .map(ns("app-type") -> _)
+        .toSeq ++
+        modules
+        .map { case (m, enabled) => ns("modules", m, "enabled") -> enabled.toString } ++
         diskSpace
         .map(ns("disk-space") -> _.toString)
         .toSeq ++

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -22,6 +22,8 @@ import scala.collection.immutable.Seq
 trait SbtReactiveAppKeys {
   val namespace = SettingKey[Option[String]]("rp-namespace")
 
+  val appType = SettingKey[String]("rp-app-type")
+
   val diskSpace = SettingKey[Option[Long]]("rp-disk-space")
 
   val memory = SettingKey[Option[Long]]("rp-memory")

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -22,6 +22,8 @@ import scala.collection.immutable.Seq
 trait SbtReactiveAppKeys {
   val namespace = SettingKey[Option[String]]("rp-namespace")
 
+  val appName = TaskKey[String]("rp-app-name")
+
   val appType = SettingKey[String]("rp-app-type")
 
   val diskSpace = SettingKey[Option[Long]]("rp-disk-space")
@@ -77,6 +79,8 @@ trait SbtReactiveAppKeys {
   val secrets = SettingKey[Set[Secret]]("rp-secrets")
 
   private[sbtreactiveapp] val akkaClusterBootstrapEnabled = TaskKey[Boolean]("rp-akka-cluster-bootstrap-enabled")
+
+  private[sbtreactiveapp] val lagomRawEndpoints = TaskKey[Seq[Endpoint]]("rp-lagom-raw-endpoints")
 
   private[sbtreactiveapp] val secretsEnabled = TaskKey[Boolean]("rp-secrets-enabled")
 }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -130,7 +130,7 @@ object SbtReactiveAppPlugin extends AutoPlugin {
         dockerCommands.value ++ addCommand ++ SbtReactiveApp
           .labels(
             namespace = namespace.value,
-            appName = Some(Keys.name.value),
+            appName = Some(appName.value),
             appType = Some(appType.value),
             diskSpace = diskSpace.value,
             memory = memory.value,
@@ -145,7 +145,7 @@ object SbtReactiveAppPlugin extends AutoPlugin {
             secrets = secrets.value,
             modules = Seq(
               "akka-cluster-bootstrapping" -> bootstrapEnabled,
-              "common" -> enableCommon.value,
+              "common" -> commonEnabled,
               "play-http-binding" -> playHttpBindingEnabled,
               "secrets" -> secretsEnabled,
               "service-discovery" -> serviceDiscoveryEnabled))

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
@@ -8,4 +8,22 @@ akkaClusterBootstrapEndpointName := "my-akka-remote"
 
 TaskKey[Unit]("check") := {
   assert(endpoints.value.contains(TcpEndpoint("my-akka-remote", 0)))
+
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """LABEL com.lightbend.rp.app-type="basic"""",
+    """LABEL com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="true"""",
+    """LABEL com.lightbend.rp.modules.common.enabled="true"""",
+    """LABEL com.lightbend.rp.modules.play-http-binding.enabled="false"""",
+    """LABEL com.lightbend.rp.modules.secrets.enabled="false""""
+  )
+
+  println(contents)
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(s"""Dockerfile is missing line "$line"""")
+    }
+  }
 }

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
@@ -1,5 +1,7 @@
 name := "akka-cluster-bootstrapping-adds-endpoint"
 
+scalaVersion := "2.11.11"
+
 enablePlugins(SbtReactiveAppPlugin)
 
 enableAkkaClusterBootstrap := Some(true)
@@ -18,8 +20,6 @@ TaskKey[Unit]("check") := {
     """LABEL com.lightbend.rp.modules.play-http-binding.enabled="false"""",
     """LABEL com.lightbend.rp.modules.secrets.enabled="false""""
   )
-
-  println(contents)
 
   lines.foreach { line =>
     if (!contents.contains(line)) {

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -65,7 +65,12 @@ TaskKey[Unit]("check") := {
     """LABEL com.lightbend.rp.secrets.0.namespace="myns1"""",
     """LABEL com.lightbend.rp.secrets.0.name="key"""",
     """LABEL com.lightbend.rp.secrets.1.namespace="myns2"""",
-    """LABEL com.lightbend.rp.secrets.1.name="otherkey""""
+    """LABEL com.lightbend.rp.secrets.1.name="otherkey"""",
+    """LABEL com.lightbend.rp.app-type="basic"""",
+    """LABEL com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="false"""",
+    """LABEL com.lightbend.rp.modules.common.enabled="true"""",
+    """LABEL com.lightbend.rp.modules.play-http-binding.enabled="false"""",
+    """LABEL com.lightbend.rp.modules.secrets.enabled="true""""
   )
 
   lines.foreach { line =>

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
@@ -22,6 +22,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -32,13 +33,15 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = None,
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map.empty
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map.empty
     }
 
     "work for all values (except checks)" in {
       SbtReactiveApp.labels(
         namespace = Some("font"),
         appName = Some("myapp"),
+        appType = Some("mytype"),
         diskSpace = Some(1234),
         memory = Some(5678),
         nrOfCpus = Some(0.25),
@@ -65,10 +68,14 @@ class SbtReactiveAppSpec extends UnitSpec {
           "env2" -> kubernetes.ConfigMapEnvironmentVariable("my-map", "my-key"),
           "env3" -> kubernetes.FieldRefEnvironmentVariable("my-field-path")),
         version = Some((1, 2, 3, Some("SNAPSHOT"))),
-        secrets = Set(Secret("myns1", "myname1"), Secret("myns2", "myname2"))) shouldBe Map(
+        secrets = Set(Secret("myns1", "myname1"), Secret("myns2", "myname2")),
+        modules = Vector("mod1" -> true, "mod2" -> false)) shouldBe Map(
 
           "com.lightbend.rp.namespace" -> "font",
           "com.lightbend.rp.app-name" -> "myapp",
+          "com.lightbend.rp.app-type" -> "mytype",
+          "com.lightbend.rp.modules.mod1.enabled" -> "true",
+          "com.lightbend.rp.modules.mod2.enabled" -> "false",
           "com.lightbend.rp.disk-space" -> "1234",
           "com.lightbend.rp.memory" -> "5678",
           "com.lightbend.rp.nr-of-cpus" -> "0.25",
@@ -142,6 +149,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -152,7 +160,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = Some(TcpCheck(90, 5)),
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map(
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.port" -> "80",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -163,6 +172,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -173,7 +183,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = Some(TcpCheck("test2", 5)),
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map(
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.service-name" -> "test",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -186,6 +197,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -196,7 +208,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = Some(HttpCheck(90, 5, "/other-health")),
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map(
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "http",
           "com.lightbend.rp.health-check.port" -> "80",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -209,6 +222,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -219,7 +233,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = Some(HttpCheck("test2", 5, "/other-health")),
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map(
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "http",
           "com.lightbend.rp.health-check.service-name" -> "test",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -234,6 +249,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         namespace = None,
         appName = None,
+        appType = None,
         diskSpace = None,
         memory = None,
         nrOfCpus = None,
@@ -244,7 +260,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         readinessCheck = Some(CommandCheck("/bin/ash", "arg 1", "arg 2")),
         environmentVariables = Map.empty,
         version = None,
-        secrets = Set.empty) shouldBe Map(
+        secrets = Set.empty,
+        modules = Vector.empty) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "command",
           "com.lightbend.rp.health-check.args.0" -> "/bin/bash",
           "com.lightbend.rp.health-check.args.1" -> "arg one",


### PR DESCRIPTION
This adds labels for the application type and what modules are enabled/disabled. We can then use this information in our CLI arbitrarily.

e.g. If `akka-cluster-bootstrapping` is enabled, the CLI can prompt for the number of contact nodes.