### PR TITLE
DONT MERGE - Add support for parsing rp.conf files and setting labels accordingly

### DIFF
--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -1,0 +1,11 @@
+# This file is loaded by [lightbend/config](https://github.com/lightbend/config) when it
+# reads the -Dconfig.resource property that we supply to the program via JAVA_OPTS.
+#
+# [reactive-lib](https://github.com/lightbend/reactive-lib) defines configuration for
+# underlying libraries it uses in rp.conf files. This pattern is comparable to Play's
+# reference-overrides.conf in that it gives us a place to configure libraries but still
+# allows settings in application.conf to take precedence.
+
+include "rp"
+
+include "application"

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -128,7 +128,7 @@ sealed trait LagomApp extends App {
     super.projectSettings ++ Vector(
       // For naming Lagom services, we take this overall approach:
       // Calculate the endpoints (lagomRawEndpoints) and make this the "appName"
-      // Then, rename the first endpoint (which is the Lagom service itself) to "lagom-api" which the
+      // Then, rename the first endpoint (which is the Lagom service itself) to "lagom-http-api" which the
       // service discovery module understands via convention.
 
       appName := lagomRawEndpoints.value.headOption.map(_.name).getOrElse(name.value),
@@ -177,7 +177,7 @@ sealed trait LagomApp extends App {
 
       endpoints := {
         lagomRawEndpoints.value.zipWithIndex.map {
-          case (e, 0) => e.withName("lagom-api")
+          case (e, 0) => e.withName("lagom-http-api")
           case (e, _) => e
         }
       } ++ endpoints.value)

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -63,6 +63,7 @@ sealed trait App extends SbtReactiveAppKeys {
     // I will need to investigate why `akkaClusterBootstrapEnabled` is a task, not a setting.
     enableServiceDiscovery := false,
     akkaClusterBootstrapEndpointName := "akka-remote",
+    akkaClusterBootstrapManagementEndpointName := "akka-mgmt-http",
     akkaClusterBootstrapEnabled := false,
 
     httpIngressHosts := Seq.empty,
@@ -85,11 +86,12 @@ sealed trait App extends SbtReactiveAppKeys {
 
     endpoints := {
       val endpointName = akkaClusterBootstrapEndpointName.value
+      val managementEndpointName = akkaClusterBootstrapManagementEndpointName.value
       val bootstrapEnabled = enableAkkaClusterBootstrap.value.getOrElse(akkaClusterBootstrapEnabled.value)
 
       endpoints.?.value.getOrElse(Seq.empty) ++ {
         if (bootstrapEnabled)
-          Seq(TcpEndpoint(endpointName, 0))
+          Seq(TcpEndpoint(endpointName, 0), TcpEndpoint(managementEndpointName, 0))
         else
           Seq.empty
       }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -44,6 +44,8 @@ trait SbtReactiveAppKeys {
 
   val akkaClusterBootstrapEndpointName = SettingKey[String]("rp-akka-cluster-bootstrap-endpoint-name")
 
+  val akkaClusterBootstrapManagementEndpointName = SettingKey[String]("rp-akka-cluster-bootstrap-management-endpoint-name")
+
   val httpIngressHosts = SettingKey[Seq[String]]("rp-ingress-hosts")
 
   val httpIngressPaths = TaskKey[Seq[String]]("rp-ingress-paths")

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -120,8 +120,13 @@ object SbtReactiveAppPlugin extends AutoPlugin {
         Seq(file)
       }.taskValue,
 
-      javaOptions in SbtNativePackager.Universal ++= Vector(
-        "-Dconfig.resource=app.conf"),
+      javaOptions in SbtNativePackager.Universal ++=
+        Vector(
+          "-Dconfig.resource=app.conf") ++
+          (
+            if (memory.value.isDefined)
+              Vector("-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap")
+            else Vector.empty),
 
       dockerEntrypoint := startScriptLocation.value.fold(dockerEntrypoint.value)(_ +: dockerEntrypoint.value),
 


### PR DESCRIPTION
Adds a feature which parses all `rp.conf` files in the class path and then sets labels at `com.lightbend.rp.jvm-properties.<name>` with the string value of the entry.

This allows, for example, `reactive-lib` to specify configuration for libraries in an `rp.conf` file. The CLI will then need to parse these labels and generate `RP_JAVA_OPTS` with `-D<property-name>=<property-value>` entries.