### PR TITLE
Add sbt scripted test for a Lagom project

### DIFF
--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -28,7 +28,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
         """ENTRYPOINT ["/rp-start", "bin/hello-impl"]""",
         """LABEL com.lightbend.rp.endpoints.0.protocol="http"""",
         """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
-        """LABEL com.lightbend.rp.endpoints.0.name="lagom-api"""",
+        """LABEL com.lightbend.rp.endpoints.0.name="lagom-http-api"""",
         """LABEL com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="false"""",
         """LABEL com.lightbend.rp.modules.play-http-binding.enabled="true"""",
         """LABEL com.lightbend.rp.app-type="lagom"""",

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -1,6 +1,7 @@
 name := "lagom-endpoints"
 scalaVersion in ThisBuild := "2.11.12"
 
+
 enablePlugins(SbtReactiveAppPlugin)
 
 lazy val `hello` = (project in file("."))
@@ -13,23 +14,45 @@ lazy val `hello-api` = (project in file("hello-api"))
     )
   )
 
+val check = taskKey[Unit]("Task for verifying Dockerfile labels")
 lazy val `hello-impl` = (project in file("hello-impl"))
-  .enablePlugins(LagomScala)
+  .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-lagom",
-    dockerExposedPorts in Docker := Seq(9000)
+    dockerExposedPorts in Docker := Seq(9000),
+    check := {
+      val outputDir = (stage in Docker).value
+      val contents = IO.readLines(outputDir / "Dockerfile")
+      val expectedLines = Seq(
+        """COPY rp-start /rp-start""",
+        """ENTRYPOINT ["/rp-start", "bin/hello-impl"]""",
+        """LABEL com.lightbend.rp.endpoints.0.protocol="http"""",
+        """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="80"""",
+        """LABEL com.lightbend.rp.endpoints.0.name="lagom-api"""",
+        """LABEL com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="false"""",
+        """LABEL com.lightbend.rp.modules.play-http-binding.enabled="true"""",
+        """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.1="443"""",
+        """LABEL com.lightbend.rp.app-type="lagom"""",
+        """LABEL com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
+        """LABEL com.lightbend.rp.app-name="hello"""",
+        """LABEL com.lightbend.rp.endpoints.0.ingress.0.paths.0="/api/hello"""",
+        """LABEL com.lightbend.rp.modules.common.enabled="true"""",
+        """LABEL com.lightbend.rp.modules.secrets.enabled="false"""",
+        """LABEL com.lightbend.rp.modules.service-discovery.enabled="true""""
+      )
+
+      println(contents)
+
+      expectedLines.foreach { line =>
+        if(!contents.contains(line)) {
+          sys.error(s"""Dockerfile is missing line "$line"""")
+        }
+      }
+
+      assert(
+        (dockerBaseImage in Docker).value == "openjdk:8-jre-alpine" || true,
+        "Docker image incorrectly set")
+    }
   )
   .dependsOn(`hello-api`)
-
-// This is just placeholder where proper test should be
-TaskKey[Unit]("check") := {
-  val outputDir = (stage in Docker).value
-  val contents = IO.readLines(outputDir / "Dockerfile")
-
-  println(contents)
-
-  assert(
-    (dockerBaseImage in Docker).value == "openjdk:8-jre-alpine" || true,
-    "Docker image incorrectly set")
-}
 

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -19,7 +19,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-lagom",
-    dockerExposedPorts in Docker := Seq(9000),
+    httpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.readLines(outputDir / "Dockerfile")
@@ -27,11 +27,10 @@ lazy val `hello-impl` = (project in file("hello-impl"))
         """COPY rp-start /rp-start""",
         """ENTRYPOINT ["/rp-start", "bin/hello-impl"]""",
         """LABEL com.lightbend.rp.endpoints.0.protocol="http"""",
-        """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="80"""",
+        """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
         """LABEL com.lightbend.rp.endpoints.0.name="lagom-api"""",
         """LABEL com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="false"""",
         """LABEL com.lightbend.rp.modules.play-http-binding.enabled="true"""",
-        """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.1="443"""",
         """LABEL com.lightbend.rp.app-type="lagom"""",
         """LABEL com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
         """LABEL com.lightbend.rp.app-name="hello"""",

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -41,8 +41,6 @@ lazy val `hello-impl` = (project in file("hello-impl"))
         """LABEL com.lightbend.rp.modules.service-discovery.enabled="true""""
       )
 
-      println(contents)
-
       expectedLines.foreach { line =>
         if(!contents.contains(line)) {
           sys.error(s"""Dockerfile is missing line "$line"""")

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -1,0 +1,35 @@
+name := "lagom-endpoints"
+scalaVersion in ThisBuild := "2.11.12"
+
+enablePlugins(SbtReactiveAppPlugin)
+
+lazy val `hello` = (project in file("."))
+  .aggregate(`hello-api`, `hello-impl`)
+
+lazy val `hello-api` = (project in file("hello-api"))
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslApi
+    )
+  )
+
+lazy val `hello-impl` = (project in file("hello-impl"))
+  .enablePlugins(LagomScala)
+  .settings(
+    packageName in Docker := "hello-lagom",
+    dockerExposedPorts in Docker := Seq(9000)
+  )
+  .dependsOn(`hello-api`)
+
+// This is just placeholder where proper test should be
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+
+  println(contents)
+
+  assert(
+    (dockerBaseImage in Docker).value == "openjdk:8-jre-alpine" || true,
+    "Docker image incorrectly set")
+}
+

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-api/src/main/scala/HelloService.scala
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-api/src/main/scala/HelloService.scala
@@ -1,0 +1,18 @@
+package lagomendpoints.api
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceCall }
+
+trait HelloService extends Service {
+  def hello(id: String): ServiceCall[NotUsed, String]
+
+  override final def descriptor = {
+    import Service._
+    // @formatter:off
+    named("hello")
+      .withCalls(
+        pathCall("/api/hello/:id", hello _))
+      .withAutoAcl(true)
+    // @formater:on
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/resources/application.conf
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+play.crypto.secret = whatever
+play.application.loader = lagomendpoints.impl.HelloLoader
+
+lagom.services {
+  hello-impl = "http://localhost:9000"
+}

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloLoader.scala
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloLoader.scala
@@ -1,0 +1,23 @@
+package lagomendpoints.impl
+
+import lagomendpoints.api.HelloService
+import com.lightbend.lagom.scaladsl.client.ConfigurationServiceLocatorComponents
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext, LagomApplicationLoader }
+import play.api.libs.ws.ahc.AhcWSComponents
+
+class HelloLoader extends LagomApplicationLoader {
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new HelloApplication(context) with ConfigurationServiceLocatorComponents
+
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new HelloApplication(context) with LagomDevModeComponents
+
+  override def describeService = Some(readDescriptor[HelloService])
+}
+
+abstract class HelloApplication(context: LagomApplicationContext)
+  extends LagomApplication(context)
+  with AhcWSComponents {
+  override lazy val lagomServer = serverFor[HelloService](new HelloServiceImpl)
+}

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloServiceImpl.scala
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloServiceImpl.scala
@@ -1,0 +1,12 @@
+package lagomendpoints.impl
+
+import lagomendpoints.api.HelloService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class HelloServiceImpl(implicit ec: ExecutionContext) extends HelloService {
+  override def hello(id: String) = ServiceCall { _ =>
+    Future { "Hello, " + id }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloServiceImpl.scala
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/hello-impl/src/main/scala/HelloServiceImpl.scala
@@ -7,6 +7,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 class HelloServiceImpl(implicit ec: ExecutionContext) extends HelloService {
   override def hello(id: String) = ServiceCall { _ =>
-    Future { "Hello, " + id }
+    Future.successful(s"Hello, $id")
   }
 }

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.10")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/project/plugins.sbt
@@ -6,4 +6,3 @@ sys.props.get("plugin.version") match {
 
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.10")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/test
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/test
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/test
@@ -1,2 +1,2 @@
-> docker:stage
+> hello-impl/docker:stage
 > check


### PR DESCRIPTION
This adds a small Lagom project test. Right now it looks at generated labels in the Dockerfile, mostly to verify endpoint discovery.