### PR TITLE
Use dockerUsername, not dockerRegistry

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -21,7 +21,7 @@ import sbt.Resolver.bintrayRepo
 import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
 import Keys._
-import com.typesafe.sbt.packager.Keys.dockerRepository
+import com.typesafe.sbt.packager.Keys.dockerUsername
 
 sealed trait App extends SbtReactiveAppKeys {
   private val ToolingConfig = "rp-tooling.conf"
@@ -185,7 +185,7 @@ sealed trait App extends SbtReactiveAppKeys {
     libraryDependencies ++=
       lib(scalaVersion.value, reactiveLibServiceDiscoveryProject.value, reactiveLibVersion.value, enableServiceDiscovery.value),
 
-    dockerRepository := namespace.value)
+    dockerUsername := namespace.value)
 
 }
 

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -35,7 +35,7 @@ object SbtReactiveAppPluginAll extends AutoPlugin {
     inConfig(docker.DockerPlugin.autoImport.Docker)(
       publish in docker.DockerPlugin.autoImport.Docker := {
         Def.taskDyn {
-          dockerRepository.?.value.nonEmpty && rpDockerPublish.?.value.nonEmpty
+          (dockerUsername.?.value.nonEmpty || dockerRepository.?.value.nonEmpty) && rpDockerPublish.?.value.nonEmpty
 
           Def.task(())
         }

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -86,8 +86,8 @@ TaskKey[Unit]("check") := {
     (dockerBaseImage in Docker).value == "openjdk:8-jre-alpine" || true,
     "Docker image incorrectly set")
 
-  val dockerRepositoryValue = (dockerRepository in Docker).value
-  val dockerRepositoryValueExpected = Some("fonts")
-  assert(dockerRepositoryValue == dockerRepositoryValueExpected,
-    s"Docker repository value is $dockerRepositoryValue - expected $dockerRepositoryValueExpected}")
+  val dockerUsernameValue = (dockerUsername in Docker).value
+  val dockerUsernameValueExpected = Some("fonts")
+  assert(dockerUsernameValue == dockerUsernameValueExpected,
+    s"Docker repository value is $dockerUsernameValue - expected $dockerUsernameValueExpected}")
 }

--- a/src/sbt-test/sbt-reactive-app/namespace-default/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/namespace-default/build.sbt
@@ -20,10 +20,10 @@ TaskKey[Unit]("check") := {
     }
   }
 
-  val dockerRepositoryValue = (dockerRepository in Docker).value
-  val dockerRepositoryValueExpected = Some("sans")
-  assert(dockerRepositoryValue == dockerRepositoryValueExpected,
-    s"Docker repository value is $dockerRepositoryValue - expected $dockerRepositoryValueExpected}")
+  val dockerUsernameValue = (dockerUsername in Docker).value
+  val dockerUsernameValueExpected = Some("sans")
+  assert(dockerUsernameValue == dockerUsernameValueExpected,
+    s"Docker repository value is $dockerUsernameValue - expected $dockerUsernameValueExpected}")
 
   val namespaceValue = namespace.value
   val namespaceValueExpected = Some("sans")

--- a/src/sbt-test/sbt-reactive-app/namespace-root-project/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/namespace-root-project/build.sbt
@@ -25,10 +25,10 @@ TaskKey[Unit]("check") := {
     }
   }
 
-  val dockerRepositoryValue = (dockerRepository in Docker in boxes).value
-  val dockerRepositoryValueExpected = Some("hello-building")
-  assert(dockerRepositoryValue == dockerRepositoryValueExpected,
-    s"Docker repository value is $dockerRepositoryValue - expected $dockerRepositoryValueExpected}")
+  val dockerUsernameValue = (dockerUsername in Docker in boxes).value
+  val dockerUsernameValueExpected = Some("hello-building")
+  assert(dockerUsernameValue == dockerUsernameValueExpected,
+    s"Docker repository value is $dockerUsernameValue - expected $dockerUsernameValueExpected}")
 
   val namespaceValue = namespace.value
   val namespaceValueExpected = Some("hello-building")


### PR DESCRIPTION
We should be setting `dockerUsername` to the root project name, not `dockerRegistry` which the end user will set to the address of their registry.