### PR TITLE
Use scala.collection.Seq for key types as its more friendly for end user

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -16,12 +16,13 @@
 
 package com.lightbend.rp.sbtreactiveapp
 
+import com.typesafe.sbt.packager.Keys.dockerUsername
 import sbt._
 import sbt.Resolver.bintrayRepo
 import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
+
 import Keys._
-import com.typesafe.sbt.packager.Keys.dockerUsername
 
 sealed trait App extends SbtReactiveAppKeys {
   private def libIsPublished(scalaVersion: String) =
@@ -229,9 +230,9 @@ sealed trait LagomApp extends App {
           magic.Lagom.endpoints(
             ((managedClasspath in apiTools).value ++ (fullClasspath in Compile).value).toVector,
             scalaInstance.value.loader,
-            ingressPorts,
-            ingressHosts,
-            ingressPaths)
+            ingressPorts.toVector,
+            ingressHosts.toVector,
+            ingressPaths.toVector)
             .getOrElse(Seq.empty)
 
         // If we don't have any magic endpoints, we want to explicitly add one for "/" as we are

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -17,7 +17,6 @@
 package com.lightbend.rp.sbtreactiveapp
 
 import sbt._
-import scala.collection.immutable.Seq
 
 trait SbtReactiveAppKeys {
   /**

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -142,7 +142,7 @@ object SbtReactiveAppPlugin extends AutoPlugin {
             diskSpace = diskSpace.value,
             memory = memory.value,
             nrOfCpus = nrOfCpus.value,
-            endpoints = endpoints.value,
+            endpoints = endpoints.value.toVector,
             volumes = volumes.value,
             privileged = privileged.value,
             healthCheck = healthCheck.value,


### PR DESCRIPTION
Title sort of says it all. We accept `scala.collection.Seq` (even though it could be mutable) as it plays nicer with SBT definitions and makes using the plugin as a user easier. For internal types, we still only accept the `scala.collection.immutable.Seq` variant.

Fixes #41 