### PR TITLE
[WIP] Bump reactive-lib to 0.3.0

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -57,7 +57,7 @@ sealed trait App extends SbtReactiveAppKeys {
     environmentVariables := Map.empty,
     startScriptLocation := Some("/rp-start"),
     secrets := Set.empty,
-    reactiveLibVersion := "0.2.2",
+    reactiveLibVersion := "0.3.0",
     reactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
     reactiveLibCommonProject := "reactive-lib-common" -> true,
     reactiveLibPlayHttpBindingProject := "reactive-lib-play-http-binding" -> true,


### PR DESCRIPTION
Marked WIP until the `reactive-lib` version is synced to Maven Central and this PR builds successfully on Travis.