### PR TITLE
Implement setting allowing different apps to join same cluster

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -220,6 +220,7 @@ case object BasicApp extends App {
       akkaClusterBootstrapEndpointName := "akka-remote",
       akkaClusterBootstrapManagementEndpointName := "akka-mgmt-http",
       akkaClusterBootstrapEnabled := false,
+      akkaClusterBootstrapSystemName := None,
 
       httpIngressHosts := Seq.empty,
 
@@ -344,6 +345,7 @@ case object BasicApp extends App {
           .map(path => docker.Cmd("COPY", localName, path))
 
         val bootstrapEnabled = enableAkkaClusterBootstrap.value.getOrElse(akkaClusterBootstrapEnabled.value)
+        val bootstrapSystemName = akkaClusterBootstrapSystemName.value.filter(_ => bootstrapEnabled)
         val commonEnabled = enableCommon.value
         val playHttpBindingEnabled = enablePlayHttpBinding.value
         val secretsEnabled = enableSecrets.value.getOrElse(secrets.value.nonEmpty)
@@ -370,7 +372,8 @@ case object BasicApp extends App {
               "common" -> commonEnabled,
               "play-http-binding" -> playHttpBindingEnabled,
               "secrets" -> secretsEnabled,
-              "service-discovery" -> serviceDiscoveryEnabled))
+              "service-discovery" -> serviceDiscoveryEnabled),
+            akkaClusterBootstrapSystemName = bootstrapSystemName)
           .map {
             case (key, value) =>
               docker.Cmd("LABEL", s"""$key="${encodeLabelValue(value)}"""")

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -35,7 +35,8 @@ object SbtReactiveApp {
     environmentVariables: Map[String, EnvironmentVariable],
     version: Option[String],
     secrets: Set[Secret],
-    modules: Seq[(String, Boolean)]): Map[String, String] = {
+    modules: Seq[(String, Boolean)],
+    akkaClusterBootstrapSystemName: Option[String]): Map[String, String] = {
     def ns(key: String*): String = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
 
     val keyValuePairs =
@@ -162,7 +163,10 @@ object SbtReactiveApp {
             Vector(
               ns("secrets", i.toString, "name") -> secret.name,
               ns("secrets", i.toString, "key") -> secret.key)
-        }
+        } ++
+        akkaClusterBootstrapSystemName
+        .toSeq
+        .map(n => ns("akka-cluster-bootstrap", "system-name") -> n)
 
     keyValuePairs.toMap
   }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -94,6 +94,12 @@ trait SbtReactiveAppKeys {
   val akkaClusterBootstrapManagementEndpointName = SettingKey[String]("rp-akka-cluster-bootstrap-management-endpoint-name")
 
   /**
+   * If specified, app will join other nodes that specify this same system name. This can be used to allow different
+   * applications to join the same cluster.
+   */
+  val akkaClusterBootstrapSystemName = SettingKey[Option[String]]("rp-akka-cluster-bootstrap-system-name")
+
+  /**
    * For endpoints that are autopopulated, they will declare ingress for these hosts. That is, they'll be available
    * on the public nodes or ingress controllers at these hostnames. Defaults to nothing for Basic apps, "/" for Play
    * apps, and the collection of service endpoints for Lagom apps.

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
@@ -12,7 +12,8 @@ lazy val root = (project in file("."))
     ),
 
     packageName in Docker := "hello-akka",
-    enableAkkaClusterBootstrap := Some(true)
+    enableAkkaClusterBootstrap := Some(true),
+    akkaClusterBootstrapSystemName := Some("hey")
   )
 
 TaskKey[Unit]("check") := {
@@ -31,12 +32,16 @@ TaskKey[Unit]("check") := {
     """LABEL com.lightbend.rp.app-name="hello-akka"""",
     """LABEL com.lightbend.rp.modules.common.enabled="true"""",
     """LABEL com.lightbend.rp.modules.secrets.enabled="false"""",
-    """LABEL com.lightbend.rp.modules.service-discovery.enabled="false""""
+    """LABEL com.lightbend.rp.modules.service-discovery.enabled="false"""",
+    """LABEL com.lightbend.rp.akka-cluster-bootstrap.system-name="hey""""
   )
 
   lines.foreach { line =>
     if (!contents.contains(line)) {
-      sys.error(s"""Dockerfile is missing line "$line"""")
+      sys.error(
+        s"""|Dockerfile is missing line "$line" - Dockerfile contents:
+            |${contents.mkString("\n")}
+            |""".stripMargin)
     }
   }
 }

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
@@ -34,7 +34,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map.empty
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map.empty
     }
 
     "work for all values (except checks)" in {
@@ -69,7 +70,8 @@ class SbtReactiveAppSpec extends UnitSpec {
           "env3" -> kubernetes.FieldRefEnvironmentVariable("my-field-path")),
         version = Some("1.2.3-SNAPSHOT"),
         secrets = Set(Secret("myns1", "myname1"), Secret("myns2", "myname2")),
-        modules = Vector("mod1" -> true, "mod2" -> false)) shouldBe Map(
+        modules = Vector("mod1" -> true, "mod2" -> false),
+        akkaClusterBootstrapSystemName = Some("test")) shouldBe Map(
 
           "com.lightbend.rp.app-name" -> "myapp",
           "com.lightbend.rp.app-type" -> "mytype",
@@ -139,7 +141,8 @@ class SbtReactiveAppSpec extends UnitSpec {
           "com.lightbend.rp.secrets.0.name" -> "myns1",
           "com.lightbend.rp.secrets.0.key" -> "myname1",
           "com.lightbend.rp.secrets.1.name" -> "myns2",
-          "com.lightbend.rp.secrets.1.key" -> "myname2")
+          "com.lightbend.rp.secrets.1.key" -> "myname2",
+          "com.lightbend.rp.akka-cluster-bootstrap.system-name" -> "test")
     }
 
     "work for tcp checks" in {
@@ -158,7 +161,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map(
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.port" -> "80",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -181,7 +185,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map(
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.service-name" -> "test",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -206,7 +211,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map(
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "http",
           "com.lightbend.rp.health-check.port" -> "80",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -231,7 +237,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map(
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "http",
           "com.lightbend.rp.health-check.service-name" -> "test",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -258,7 +265,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
-        modules = Vector.empty) shouldBe Map(
+        modules = Vector.empty,
+        akkaClusterBootstrapSystemName = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "command",
           "com.lightbend.rp.health-check.args.0" -> "/bin/bash",
           "com.lightbend.rp.health-check.args.1" -> "arg one",


### PR DESCRIPTION
This PR implements a setting, `akkaClusterBootstrapSystemName`, that can force different apps in the same namespace to join the same cluster. It will require CLI changes as well.