### PR TITLE
Implement support for applications, Alpine packages, bash as default

### DIFF
--- a/src/main/resources/rp-start
+++ b/src/main/resources/rp-start
@@ -6,39 +6,12 @@
 
 set -e
 
-# Lots of people seem to want to use these images outside of intended
-# platforms, so warn if that's the case
-
-if [ "$RP_PLATFORM" = "" ]; then
-  echo "********************************************************************************"
-  echo "* Unable to detect active platform; this Docker image is intended to be run in *"
-  echo "* a supported orchestration environment such as Kubernetes, not stand-alone.   *"
-  echo "********************************************************************************"
-
-  exit 1
-fi
-
 # Our tooling generates RP_JAVA_OPTS so that we stay separate from
 # JAVA_OPTS, so add that to JAVA_OPTS which the native packager script
 # will respect.
 
 if [ "$RP_JAVA_OPTS" != "" ]; then
   export JAVA_OPTS="$RP_JAVA_OPTS $JAVA_OPTS"
-fi
-
-# @TODO FIXME when upstream fixes this, see https://github.com/sbt/sbt-native-packager/issues/978
-# Hack around a bug in sbt-native-packager causing args
-# to not work when Ash Scripting is enabled
-
-if [ -d "$PWD/bin" ]; then
-  cat <<EOT >> "$PWD/bin/is_cygwin"
-#!/usr/bin/env sh
-exit 1
-EOT
-
-  chmod +x "$PWD/bin/is_cygwin"
-
-  export PATH="$PWD/bin:$PATH"
 fi
 
 exec "$@"

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -183,7 +183,7 @@ case object PlayApp extends App {
 case object BasicApp extends App {
   def projectSettings: Seq[Setting[_]] =
     Vector(
-      alpinePackages := Vector("bash"),
+      alpinePackages := Vector.empty,
       appName := name.value,
       appType := "basic",
       applications := Vector("default" -> Vector(s"bin/${executableScriptName.value}")),
@@ -202,6 +202,7 @@ case object BasicApp extends App {
       reactiveLibSecretsProject := "reactive-lib-secrets" -> true,
       reactiveLibServiceDiscoveryProject := "reactive-lib-service-discovery" -> true,
       reactiveLibStatusProject := "reactive-lib-status" -> true,
+      requiredAlpinePackages := Vector("bash"),
       enableAkkaClusterBootstrap := false,
       enableAkkaManagement := enableAkkaClusterBootstrap.value || enableStatus.value,
       enableCommon := true,
@@ -337,13 +338,15 @@ case object BasicApp extends App {
         val akkaManagementEnabled = bootstrapEnabled || statusEnabled
         val rawDockerCommands = dockerCommands.value
         val alpinePackagesValue = alpinePackages.value
+        val requiredAlpinePackagesValue = requiredAlpinePackages.value
+        val allAlpinePackages = (alpinePackagesValue ++ requiredAlpinePackagesValue).distinct.sorted
 
         val dockerWithPackagesCommands =
-          if (rawDockerCommands.isEmpty || alpinePackagesValue.isEmpty)
+          if (rawDockerCommands.isEmpty || allAlpinePackages.isEmpty)
             rawDockerCommands
           else
             rawDockerCommands.head +:
-              docker.Cmd("RUN", Vector("/sbin/apk", "add", "--no-cache") ++ alpinePackagesValue: _*) +:
+              docker.Cmd("RUN", Vector("/sbin/apk", "add", "--no-cache") ++ allAlpinePackages: _*) +:
               rawDockerCommands.tail
 
         dockerWithPackagesCommands ++ addCommand ++ SbtReactiveApp

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -23,6 +23,7 @@ object SbtReactiveApp {
   def labels(
     appName: Option[String],
     appType: Option[String],
+    applications: Seq[(String, Seq[String])],
     configResource: Option[String],
     diskSpace: Option[Long],
     memory: Option[Long],
@@ -40,6 +41,18 @@ object SbtReactiveApp {
       appName
         .map(ns("app-name") -> _.toString)
         .toSeq ++
+        applications
+        .zipWithIndex
+        .flatMap {
+          case ((appN, appArgs), i) =>
+            (ns("applications", i.toString, "name") -> appN) +:
+              appArgs
+              .zipWithIndex
+              .map {
+                case (arg, argIndex) =>
+                  ns("applications", i.toString, "arguments", argIndex.toString) -> arg
+              }
+        } ++
         version
         .map(ns("app-version") -> _)
         .toSeq ++

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -85,6 +85,18 @@ trait SbtReactiveAppKeys {
   val akkaManagementEndpointName = SettingKey[String]("rp-akka-management-endpoint-name")
 
   /**
+   * Defines packages to install on top of the base alpine image. By default, this includes bash but you can
+   * arbitrarily add to it by using +=, e.g. `alpinePackages += "coreutils"`
+   */
+  val alpinePackages = SettingKey[Seq[String]]("rp-alpine-packages")
+
+  /**
+   * Defines the available applications. This is a list of appName -> appArgs. The operator can specify alternate
+   * applications to dynamically override the command/arguments that are executed.
+   */
+  val applications = TaskKey[Seq[(String, Seq[String])]]("rp-applications")
+
+  /**
    * For endpoints that are autopopulated, they will declare ingress for these hosts. That is, they'll be available
    * on the public nodes or ingress controllers at these hostnames. Defaults to nothing for Basic apps, "/" for Play
    * apps, and the collection of service endpoints for Lagom apps.

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -85,8 +85,7 @@ trait SbtReactiveAppKeys {
   val akkaManagementEndpointName = SettingKey[String]("rp-akka-management-endpoint-name")
 
   /**
-   * Defines packages to install on top of the base alpine image. By default, this includes bash but you can
-   * arbitrarily add to it by using +=, e.g. `alpinePackages += "coreutils"`
+   * Defines packages to install on top of the base alpine image.
    */
   val alpinePackages = SettingKey[Seq[String]]("rp-alpine-packages")
 
@@ -203,4 +202,10 @@ trait SbtReactiveAppKeys {
   private[sbtreactiveapp] val reactiveLibServiceDiscoveryProject = SettingKey[(String, Boolean)]("rp-reactive-lib-service-discovery-project")
 
   private[sbtreactiveapp] val reactiveLibStatusProject = SettingKey[(String, Boolean)]("rp-reactive-lib-status-project")
+
+  /**
+   * Defines alpine packages that are installed (and required) by this plugin. This is combined with the user-defined
+   * packages (`alpinePackages`).
+   */
+  private[sbtreactiveapp] val requiredAlpinePackages = SettingKey[Seq[String]]("rp-required-alpine-packages")
 }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -17,7 +17,7 @@
 package com.lightbend.rp.sbtreactiveapp
 
 import com.typesafe.sbt.packager.Keys._
-import com.typesafe.sbt.packager.archetypes.scripts.AshScriptPlugin
+import com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptPlugin
 import com.typesafe.sbt.packager.docker
 import sbt._
 import sbt.Keys._
@@ -93,23 +93,13 @@ object SbtReactiveAppPlugin extends AutoPlugin {
 
   object localImport extends docker.DockerKeys
 
-  override def requires = SbtReactiveAppPluginAll && docker.DockerPlugin && AshScriptPlugin && SbtReactiveAppPluginAll
+  override def requires = SbtReactiveAppPluginAll && docker.DockerPlugin && BashStartScriptPlugin && SbtReactiveAppPluginAll
 
   override def trigger = noTrigger
 
   val Docker = docker.DockerPlugin.autoImport.Docker
 
   val localName = "rp-start"
-
-  private def encodeLabelValue(value: String) =
-    value
-      .replaceAllLiterally("\n", "\\\n")
-      .replaceAllLiterally("\"", "\\\"")
-
-  private def readResource(name: String): String =
-    scala.io.Source
-      .fromInputStream(getClass.getClassLoader.getResourceAsStream(name))
-      .mkString
 
   override def projectSettings: Seq[Setting[_]] = BasicApp.projectSettings
 }

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
@@ -20,8 +20,6 @@ TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """ENTRYPOINT ["/rp-start", "bin/hello-akka"]""",
-    """COPY rp-start /rp-start""",
     """LABEL com.lightbend.rp.endpoints.0.protocol="tcp"""",
     """LABEL com.lightbend.rp.endpoints.0.name="akka-remote"""",
     """LABEL com.lightbend.rp.endpoints.1.protocol="tcp"""",

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
@@ -1,16 +1,14 @@
-name := "start-script-disabled"
+name := "alpine-packages"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-startScriptLocation := ""
+alpinePackages += "coreutils"
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """ENTRYPOINT []""",
-    """LABEL com.lightbend.rp.applications.0.name="default"""",
-    """LABEL com.lightbend.rp.applications.0.arguments.0="bin/start-script-disabled"""")
+    """RUN /sbin/apk add --no-cache bash coreutils""")
 
   lines.foreach { line =>
     if (!contents.contains(line)) {

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/test
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -18,8 +18,6 @@ TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """COPY rp-start /rp-start""",
-    """ENTRYPOINT ["/rp-start", "bin/labels"]""",
     """LABEL com.lightbend.rp.config-resource="rp-application.conf"""",
     """LABEL com.lightbend.rp.app-name="labels"""",
     """LABEL com.lightbend.rp.disk-space="32768"""",

--- a/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-endpoints/build.sbt
@@ -31,8 +31,6 @@ lazy val `hello-impl` = (project in file("hello-impl"))
       val outputDir = (stage in Docker).value
       val contents = IO.readLines(outputDir / "Dockerfile")
       val expectedLines = Seq(
-        """COPY rp-start /rp-start""",
-        """ENTRYPOINT ["/rp-start", "bin/hello-impl"]""",
         """LABEL com.lightbend.rp.endpoints.0.protocol="http"""",
         """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
         """LABEL com.lightbend.rp.endpoints.0.name="http"""",

--- a/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
@@ -15,8 +15,6 @@ TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """ENTRYPOINT ["/rp-start", "bin/hello-play"]""",
-    """COPY rp-start /rp-start""",
     """LABEL com.lightbend.rp.endpoints.0.protocol="http"""",
     """LABEL com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
     """LABEL com.lightbend.rp.endpoints.0.ingress.0.type="http"""",

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
@@ -4,15 +4,27 @@ enablePlugins(SbtReactiveAppPlugin)
 
 startScriptLocation := "/my-rp-entry"
 
+applications += "cleanup" -> Seq("bin/test")
+
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """ENTRYPOINT ["/my-rp-entry", "bin/start-script-enabled"]""")
+    """COPY rp-start /my-rp-entry""",
+    """ENTRYPOINT []""",
+    """LABEL com.lightbend.rp.applications.0.name="default"""",
+    """LABEL com.lightbend.rp.applications.0.arguments.0="/my-rp-entry"""",
+    """LABEL com.lightbend.rp.applications.0.arguments.1="bin/start-script-enabled"""",
+    """LABEL com.lightbend.rp.applications.1.name="cleanup"""",
+    """LABEL com.lightbend.rp.applications.1.arguments.0="/my-rp-entry"""",
+    """LABEL com.lightbend.rp.applications.1.arguments.1="bin/test"""")
 
   lines.foreach { line =>
     if (!contents.contains(line)) {
-      sys.error(s"""Dockerfile is missing line "$line"""")
+      sys.error(
+        s"""|Dockerfile is missing line "$line" - Dockerfile contents:
+            |${contents.mkString("\n")}
+            |""".stripMargin)
     }
   }
 }

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
@@ -22,6 +22,7 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         appName = None,
         appType = None,
+        applications = Vector.empty,
         configResource = None,
         diskSpace = None,
         memory = None,
@@ -40,6 +41,9 @@ class SbtReactiveAppSpec extends UnitSpec {
       SbtReactiveApp.labels(
         appName = Some("myapp"),
         appType = Some("mytype"),
+        applications = Vector(
+          "default" -> Vector("com.acme.Hello1", "test"),
+          "alt" -> Vector("com.acme.Hello2")),
         configResource = Some("my-config.conf"),
         diskSpace = Some(1234),
         memory = Some(5678),
@@ -65,7 +69,11 @@ class SbtReactiveAppSpec extends UnitSpec {
         secrets = Set(Secret("myns1", "myname1"), Secret("myns2", "myname2")),
         modules = Vector("mod1" -> true, "mod2" -> false),
         akkaClusterBootstrapSystemName = Some("test")) shouldBe Map(
-
+          "com.lightbend.rp.applications.0.name" -> "default",
+          "com.lightbend.rp.applications.0.arguments.0" -> "com.acme.Hello1",
+          "com.lightbend.rp.applications.0.arguments.1" -> "test",
+          "com.lightbend.rp.applications.1.name" -> "alt",
+          "com.lightbend.rp.applications.1.arguments.0" -> "com.acme.Hello2",
           "com.lightbend.rp.app-name" -> "myapp",
           "com.lightbend.rp.app-type" -> "mytype",
           "com.lightbend.rp.config-resource" -> "my-config.conf",


### PR DESCRIPTION
This adds an SBT setting, `applications`, with a default value equal to the concatenation of Docker entrypoint and cmd entries.

A user can add additional applications to easily allow the operator (person using CLI) to select from multiple applications that are embedded in the image, simply by name instead of having to provide script path and arguments.

Example scenario: A Docker image has a default application and a cleanup script. The developer can add the cleanup script as an `application` in the Docker image (via e.g. `applications += "cleanup" -> Seq("bin/test")
`).

The operator can then generate two sets of resources simply by specifying `--application default` (perhaps the default) or `--application cleanup` instead of having to know about the layout of the Docker image.

This will need a CLI PR to implement the corresponding functionality there.

--------------------

In addition, this PR adds a setting `alpinePackages` that will install the declared packages as part of the Docker image. This defaults to `Vector("bash")`, because:

In addition, the default scripting has been changed back to bash. Ash support in sbt-native-packager is particularly broken when it comes to multiple main classes, so this is a safer choice.