### PR TITLE
Fix Lagom 1.4 support

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -121,7 +121,7 @@ case object LagomJavaApp extends LagomApp {
       .version
       .toVector
       .map(v =>
-        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> false)
+        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> true)
 }
 
 case object LagomScalaApp extends LagomApp {
@@ -138,7 +138,7 @@ case object LagomPlayJavaApp extends LagomApp {
       .version
       .toVector
       .map(v =>
-        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> false)
+        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> true)
 }
 
 case object LagomPlayScalaApp extends LagomApp {


### PR DESCRIPTION
Complementing https://github.com/lightbend/reactive-lib/pull/48

We weren't publishing the Java modules correctly. They still need to be cross published because they depend on scala libs.