### PR TITLE
Change default contact points for deploy to be 1

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -224,7 +224,7 @@ case object BasicApp extends App {
         "kafka_native" -> "_broker._tcp.reactive-sandbox-kafka.default.svc.cluster.local",
         "elastic-search" -> "_http._tcp.reactive-sandbox-elasticsearch.default.svc.cluster.local"),
       deployMinikubeAdditionalExternalServices := Map.empty,
-      deployMinikubeAkkaClusterBootstrapContactPoints := 2,
+      deployMinikubeAkkaClusterBootstrapContactPoints := 1,
       deployMinikubePlayHostAllowedProperty := "play.filters.hosts.allowed.0",
       deployMinikubePlayHttpSecretKeyProperty := "play.http.secret.key",
       deployMinikubePlayHttpSecretKeyValue := "dev-minikube",
@@ -331,7 +331,7 @@ case object BasicApp extends App {
                 dockerAlias.value.versioned,
                 "--env",
                 s"JAVA_OPTS=${javaOpts.mkString(" ")}") ++
-                (if (bootstrapEnabled) Vector("--pod-controller-replicas", deployMinikubeAkkaClusterBootstrapContactPoints.value.toString) else Vector.empty) ++
+                (if (bootstrapEnabled) Vector("--akka-cluster-skip-validation", "--pod-controller-replicas", deployMinikubeAkkaClusterBootstrapContactPoints.value.toString) else Vector.empty) ++
                 serviceArgs ++
                 deployMinikubeRpArguments.value
 


### PR DESCRIPTION
Requires a release of CLI with https://github.com/lightbend/reactive-cli/pull/112

Adjusts the default contact points to be 1 when using `deploy minikube`. This will avoid Cassandra keyspace/table initialization race that happens when multiple services are being deployed.

Since this command is for development, this solution is okay. For production, we recommend that tables/keyspaces be created ahead of time, so the issue isn't relevant there.