### PR TITLE
Add support for RP_DYN_JAVA_OPTS

### DIFF
--- a/src/main/resources/rp-start
+++ b/src/main/resources/rp-start
@@ -14,4 +14,11 @@ if [ "$RP_JAVA_OPTS" != "" ]; then
   export JAVA_OPTS="$RP_JAVA_OPTS $JAVA_OPTS"
 fi
 
+# Also support setting options that are dynamically evaluated, e.g.
+# they may need to know environment variables that K8s/Marathon set.
+
+if [ "$RP_DYN_JAVA_OPTS" != "" ]; then
+  export JAVA_OPTS="$(eval "echo $RP_DYN_JAVA_OPTS") $JAVA_OPTS"
+fi
+
 exec "$@"


### PR DESCRIPTION
This is the SBT plugin side of https://github.com/lightbend/reactive-cli/issues/124

Then, we can have the CLI ensure that env var `RP_KUBERNETES_NAMESPACE` is set (resolved by k8s dynamically), and we can add this parameter to `RP_DYN_JAVA_OPTS`:

```
-Dakka.management.whatever=$RP_KUBERNETES_NAMESPACE
```