### PR TITLE
Ensure minikube docker-env is for bash

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -282,7 +282,7 @@ case object BasicApp extends App {
                    |
                    |set -e
                    |
-                   |eval $(minikube docker-env)
+                   |eval $(minikube docker-env --shell bash)
                    |
                    |exec "$@"
                    |""".stripMargin)


### PR DESCRIPTION
Just noticed that I had this change locally from some time ago. Make sure docker-env is using bash syntax, so this script can run under other shells (I was using fish shell).