### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
 script:
   - sbt ^test
+  - sbt ^publishLocal
   - sbt ^scripted


### PR DESCRIPTION
Our automatic Travis CI builds mysteriously switched off few weeks ago.

Trying to reintroduce them now I get `com.lightbend.rp#sbt-reactive-app;1.2.2-SNAPSHOT: not found` on scripted integration tests. Doing `sbt publishLocal` should fix that, though I'm not sure why it was working before. Maybe a change in sbt behaviour? 