### PR TITLE
Add runAsUser settings

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -66,6 +66,26 @@ trait SbtReactiveAppKeys {
   val privileged = SettingKey[Boolean]("rp-privileged")
 
   /**
+   * Run application as the given user. Defaults to `daemon`.
+   */
+  val runAsUser = SettingKey[String]("rp-run-as-user", "Run application as the given user. Defaults to `daemon`.")
+
+  /**
+   * Group that the user belongs to. Defaults to the user name.
+   */
+  val runAsUserGroup = SettingKey[String]("rp-run-as-user-group", "Group that the user belongs to. Defaults to the user name.")
+
+  /**
+   * UID of the user.
+   */
+  val runAsUserUID = SettingKey[Int]("rp-run-as-user-uid", "UID of the user.")
+
+  /**
+   * GID of the user's group.
+   */
+  val runAsUserGID = SettingKey[Int]("rp-run-as-user-gid", "GID of the user's group.")
+
+  /**
    * Defines the endpoint name for the akka remoting port. reactive-lib expects the default values here so you
    * should not have to change this under normal circumstances.
    */

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/build.sbt
@@ -1,0 +1,28 @@
+name := "run-as-use-group-uid-gid"
+scalaVersion := "2.12.4"
+enablePlugins(SbtReactiveAppPlugin)
+
+runAsUser := "rpuser"
+runAsUserGroup := "rpgroup"
+runAsUserUID := 50
+runAsUserGID := 60
+
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """RUN id -g rpgroup || addgroup -g 60 rpgroup""",
+    """RUN id -u rpuser || adduser -u 50 rpuser rpgroup""",
+    """COPY --chown=rpuser:rpgroup rp-start /rp-start""",
+    """USER rpuser"""
+  )
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(
+        s"""|Dockerfile is missing line "$line" - Dockerfile contents:
+            |${contents.mkString("\n")}
+            |""".stripMargin)
+    }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.4

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/test
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check

--- a/src/sbt-test/sbt-reactive-app/run-as-user/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/build.sbt
@@ -1,0 +1,25 @@
+name := "run-as-user"
+scalaVersion := "2.12.4"
+enablePlugins(SbtReactiveAppPlugin)
+
+runAsUser := "rpuser"
+
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """RUN id -g rpuser || addgroup rpuser""",
+    """RUN id -u rpuser || adduser rpuser rpuser""",
+    """COPY --chown=rpuser:rpuser rp-start /rp-start""",
+    """USER rpuser"""
+  )
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(
+        s"""|Dockerfile is missing line "$line" - Dockerfile contents:
+            |${contents.mkString("\n")}
+            |""".stripMargin)
+    }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.4

--- a/src/sbt-test/sbt-reactive-app/run-as-user/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/run-as-user/test
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check


### PR DESCRIPTION
Add 4 new settings:
* `runAsUser` - runs the application as the given user
* `runAsUserGroup` - group of the user
* `runAsUserUID` - uid of the user
* `runAsUserGID` - gid of the user's group

Defaults:
* `runAsUser` - `daemon`, same as existing behavior
* `runAsUserGroup` - value of `runAsUser`
* `runAsUserUID` - unset, so dynamically generated
* `runAsUserGID` - unset, so dynamically generated

I didn't use `-S`, to prevent a security issue where a dynamically
generated uid/gid could be the same as a host level system account.

Fixes https://github.com/lightbend/sbt-reactive-app/issues/111