### PR TITLE
Add support for exporting annotations

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -386,6 +386,7 @@ case object BasicApp extends App {
       environmentVariables := Map.empty,
       startScriptLocation := "/rp-start",
       secrets := Set.empty,
+      annotations := Map.empty,
       reactiveLibVersion := "0.8.2",
       reactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
       reactiveLibCommonProject := "reactive-lib-common" -> true,

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -549,6 +549,7 @@ case object BasicApp extends App {
             environmentVariables = environmentVariables.value,
             version = Some(Keys.version.value),
             secrets = secrets.value,
+            annotations = annotations.value,
             modules = Seq(
               "akka-cluster-bootstrapping" -> bootstrapEnabled,
               "akka-management" -> akkaManagementEnabled,

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -34,6 +34,7 @@ object SbtReactiveApp {
     environmentVariables: Map[String, EnvironmentVariable],
     version: Option[String],
     secrets: Set[Secret],
+    annotations: Map[String, String],
     modules: Seq[(String, Boolean)],
     akkaClusterBootstrapSystemName: Option[String]): Seq[(String, String)] = {
     def ns(key: String*): String = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
@@ -154,6 +155,15 @@ object SbtReactiveApp {
           Vector(
             ns("secrets", i.toString, "name") -> secret.name,
             ns("secrets", i.toString, "key") -> secret.key)
+      } ++
+      annotations
+      .toSeq
+      .zipWithIndex
+      .flatMap {
+        case (annotation, i) =>
+          Vector(
+            ns("annotations", i.toString, "key") -> annotation._1,
+            ns("annotations", i.toString, "value") -> annotation._2)
       } ++
       akkaClusterBootstrapSystemName
       .toSeq

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -283,6 +283,15 @@ trait SbtReactiveAppKeys {
    */
   val secrets = SettingKey[Set[Secret]]("rp-secrets")
 
+  /**
+   * Annotations to attach to the application at runtime. On Kubernetes, this will become a pod annotation. On
+   * DC/OS it will be a label.
+   */
+  val annotations = SettingKey[Map[String, String]](
+    "rp-annotations",
+    "Annotations to attach to the application at runtime. On Kubernetes, this will become a pod annotation. " +
+      "On DC/OS it will be a label.")
+
   private[sbtreactiveapp] val deployMinikubeDockerEnv = TaskKey[String]("rp-deploy-minikube-docker-env")
 
   private[sbtreactiveapp] val lagomRawEndpoints = TaskKey[Seq[Endpoint]]("rp-lagom-raw-endpoints")

--- a/src/sbt-test/sbt-reactive-app/export-annotations/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/build.sbt
@@ -1,0 +1,29 @@
+name := "export-annotations"
+scalaVersion := "2.12.4"
+enablePlugins(SbtReactiveAppPlugin)
+
+annotations := Map("es.lightbend.com/scrape" -> "true",
+                   "es.lightbend.com/port" -> "metrics",
+                   "es.lightbend.com/path" -> "/metrics")
+
+TaskKey[Unit]("check") := {
+  val outputDir = (stage in Docker).value
+  val contents = IO.readLines(outputDir / "Dockerfile")
+  val lines = Seq(
+    """com.lightbend.rp.annotations.0.key="es.lightbend.com/scrape" \""",
+    """com.lightbend.rp.annotations.0.value="true" \""",
+    """com.lightbend.rp.annotations.1.key="es.lightbend.com/port" \""",
+    """com.lightbend.rp.annotations.1.value="metrics" \""",
+    """com.lightbend.rp.annotations.2.key="es.lightbend.com/path" \""",
+    """com.lightbend.rp.annotations.2.value="/metrics" \"""
+  )
+
+  lines.foreach { line =>
+    if (!contents.contains(line)) {
+      sys.error(
+        s"""|Dockerfile is missing line "$line" - Dockerfile contents:
+            |${contents.mkString("\n")}
+            |""".stripMargin)
+    }
+  }
+}

--- a/src/sbt-test/sbt-reactive-app/export-annotations/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.6

--- a/src/sbt-test/sbt-reactive-app/export-annotations/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-reactive-app/export-annotations/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-reactive-app/export-annotations/test
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/test
@@ -1,0 +1,2 @@
+> docker:stage
+> check

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
@@ -32,6 +32,7 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map.empty,
         version = None,
         secrets = Set.empty,
+        annotations = Map.empty,
         modules = Vector.empty,
         akkaClusterBootstrapSystemName = None) shouldBe Seq(
         "com.lightbend.rp.sbt-reactive-app-version" -> ProgramVersion.current)
@@ -67,6 +68,7 @@ class SbtReactiveAppSpec extends UnitSpec {
           "env3" -> kubernetes.FieldRefEnvironmentVariable("my-field-path")),
         version = Some("1.2.3-SNAPSHOT"),
         secrets = Set(Secret("myns1", "myname1"), Secret("myns2", "myname2")),
+        annotations = Map("mykey1" -> "myval1", "mykey2" -> "myval2"),
         modules = Vector("mod1" -> true, "mod2" -> false),
         akkaClusterBootstrapSystemName = Some("test")).toMap shouldBe Map(
           "com.lightbend.rp.applications.0.name" -> "default",
@@ -137,6 +139,10 @@ class SbtReactiveAppSpec extends UnitSpec {
           "com.lightbend.rp.secrets.0.key" -> "myname1",
           "com.lightbend.rp.secrets.1.name" -> "myns2",
           "com.lightbend.rp.secrets.1.key" -> "myname2",
+          "com.lightbend.rp.annotations.0.key" -> "mykey1",
+          "com.lightbend.rp.annotations.0.value" -> "myval1",
+          "com.lightbend.rp.annotations.1.key" -> "mykey2",
+          "com.lightbend.rp.annotations.1.value" -> "myval2",
           "com.lightbend.rp.akka-cluster-bootstrap.system-name" -> "test",
           "com.lightbend.rp.sbt-reactive-app-version" -> ProgramVersion.current)
     }


### PR DESCRIPTION
This adds a new setting `annotations`. It's a map that takes key-value
pairs for annotations that will be exported as labels in the Dockerfile:

        annotations := Map("es.lightbend.com/scrape" -> "true",
                           "es.lightbend.com/port" -> "metrics")

Will become:

        "com.lightbend.rp.annotations.0.key"="es.lightbend.com/scrape" \
        "com.lightbend.rp.annotations.0.value"="true" \
        "com.lightbend.rp.annotations.1.key"="es.lightbend.com/port" \
        "com.lightbend.rp.annotations.1.value"="metrics" \

This can then be used by reactive-cli to set annotations or labels on
either Kubernetes or DC/OS resources.