### PR TITLE
Default annotations in Global scope

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -203,7 +203,7 @@ case object BasicApp extends App {
   private val reactiveSandboxInstalledLatch = new java.util.concurrent.CountDownLatch(1)
 
   def globalSettings: Seq[Setting[_]]  = Seq(
-    annotations := Map.empty,
+    annotations := Map.empty
   )
 
   def buildSettings: Seq[Setting[_]] =

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -202,6 +202,10 @@ case object BasicApp extends App {
   private val installReactiveSandbox = new java.util.concurrent.atomic.AtomicBoolean(false)
   private val reactiveSandboxInstalledLatch = new java.util.concurrent.CountDownLatch(1)
 
+  def globalSettings: Seq[Setting[_]]  = Seq(
+    annotations := Map.empty,
+  )
+
   def buildSettings: Seq[Setting[_]] =
     Vector(
       deployMinikubeReactiveSandboxCqlStatements := Seq.empty,
@@ -404,7 +408,6 @@ case object BasicApp extends App {
       environmentVariables := Map.empty,
       startScriptLocation := "/rp-start",
       secrets := Set.empty,
-      annotations := Map.empty,
       reactiveLibVersion := App.defaultReactiveLibVersion,
       reactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
       reactiveLibCommonProject := "reactive-lib-common" -> true,

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -102,6 +102,8 @@ object SbtReactiveAppPlugin extends AutoPlugin {
 
   val localName = "rp-start"
 
+  override def globalSettings: Seq[Setting[_]] = BasicApp.globalSettings
+
   override def buildSettings: Seq[Setting[_]] = BasicApp.buildSettings
 
   override def projectSettings: Seq[Setting[_]] = BasicApp.projectSettings


### PR DESCRIPTION
This allows for annotations to be redefined in build scope, without the
plugin going and resetting the definition.