### PR TITLE
Remove Lagom version detection

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -135,36 +135,26 @@ sealed trait LagomApp extends App {
 
 case object LagomJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
-    super.projectSettings ++ magic.Lagom
-      .version
-      .toVector
-      .map(v =>
-        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> true)
+    super.projectSettings :+
+      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
 }
 
 case object LagomScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
-    super.projectSettings ++ magic.Lagom
-      .version
-      .toVector
-      .map(v => reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-scala" -> true)
+    super.projectSettings :+
+      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
 }
 
 case object LagomPlayJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
-    super.projectSettings ++ magic.Lagom
-      .version
-      .toVector
-      .map(v =>
-        reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-java" -> true)
+    super.projectSettings :+
+      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
 }
 
 case object LagomPlayScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
-    super.projectSettings ++ magic.Lagom
-      .version
-      .toVector
-      .map(v => reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom${SemVer.formatMajorMinor(v)}-scala" -> true)
+    super.projectSettings :+
+      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
 }
 
 case object PlayApp extends App {
@@ -202,9 +192,8 @@ case object BasicApp extends App {
   private val installReactiveSandbox = new java.util.concurrent.atomic.AtomicBoolean(false)
   private val reactiveSandboxInstalledLatch = new java.util.concurrent.CountDownLatch(1)
 
-  def globalSettings: Seq[Setting[_]]  = Seq(
-    annotations := Map.empty
-  )
+  def globalSettings: Seq[Setting[_]] = Seq(
+    annotations := Map.empty)
 
   def buildSettings: Seq[Setting[_]] =
     Vector(
@@ -661,8 +650,6 @@ case object BasicApp extends App {
 }
 
 private object SemVer {
-  def formatMajorMinor(version: String): String = version.filterNot(_ == '.').take(2)
-
   def parse(version: String): Option[(Int, Int, Int, Option[String])] = {
     val parts = version.split("\\.", 3)
 

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Lagom.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Lagom.scala
@@ -88,6 +88,7 @@ object Lagom {
     }
   }
 
+  @deprecated("use com.lightbend.lagom.core.LagomVersion.current", "sbt-reactive-app 1.4.0")
   def version: Option[String] = {
     // The method signature equals the signature of `com.lightbend.lagom.core.LagomVersion`
     type LagomVersion = {

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SemVerSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SemVerSpec.scala
@@ -17,14 +17,6 @@
 package com.lightbend.rp.sbtreactiveapp
 
 class SemVerSpec extends UnitSpec {
-  "formatMajorMinor" should {
-    "work" in {
-      SemVer.formatMajorMinor("1.0.0") shouldEqual "10"
-      SemVer.formatMajorMinor("1.0.1") shouldEqual "10"
-      SemVer.formatMajorMinor("3.2.3") shouldEqual "32"
-    }
-  }
-
   "parse" should {
     "correctly parse a semantic version number" in {
       SemVer.parse("1.2.3") shouldEqual Some((1, 2, 3, None))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.2-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
Fixes #136

In line with my recommendation there, my approach was to remove all of the code that tries to detect the Lagom version, and simply hardcode dependencies on `reactive-lib-service-discovery-lagom14-java` and `reactive-lib-service-discovery-lagom14-scala`, the only versions that currently exist, and the only ones we anticipate needing.

The implementation is complete, and I'm opening a pull request now to get early feedback from people in other time zones, but there's still more testing that I'll need to do tomorrow.

- [x] Test `sbt runAll` with Lagom 1.5.0-SNAPSHOT
- [x] Test Kubernetes deployment with Lagom 1.5.0-SNAPSHOT
- [x] Regression test `sbt runAll` with Lagom 1.4.7
- [x] Regression test Kubernetes deployment with Lagom 1.4.7

(Of course, if anyone else wants to help test some of these, please go right ahead.)