### PR TITLE
Rename keys to be rp-prefixed & camelCased

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -72,17 +72,17 @@ sealed trait LagomApp extends App {
   def projectSettings: Seq[Setting[_]] =
     Vector(
       // For naming Lagom services, we take this overall approach:
-      // Calculate the endpoints (lagomRawEndpoints) and make this the "appName"
+      // Calculate the endpoints (rpLagomRawEndpoints) and make this the "appName"
 
-      appName := lagomRawEndpoints.value.headOption.map(_.name).getOrElse(name.value),
+      rpAppName := rpLagomRawEndpoints.value.headOption.map(_.name).getOrElse(name.value),
 
-      appType := "lagom",
+      rpAppType := "lagom",
 
-      enableAkkaClusterBootstrap := magic.Lagom.hasCluster(libraryDependencies.value.toVector),
+      rpEnableAkkaClusterBootstrap := magic.Lagom.hasCluster(libraryDependencies.value.toVector),
 
-      enablePlayHttpBinding := true,
+      rpEnablePlayHttpBinding := true,
 
-      enableServiceDiscovery := true,
+      rpEnableServiceDiscovery := true,
 
       ivyConfigurations += ApiTools,
 
@@ -91,10 +91,10 @@ sealed trait LagomApp extends App {
 
       libraryDependencies ++= magic.Lagom.component("api-tools").toVector.map(_ % ApiTools),
 
-      lagomRawEndpoints := {
-        val ingressPorts = httpIngressPorts.value
-        val ingressHosts = httpIngressHosts.value
-        val ingressPaths = httpIngressPaths.value
+      rpLagomRawEndpoints := {
+        val ingressPorts = rpHttpIngressPorts.value
+        val ingressHosts = rpHttpIngressHosts.value
+        val ingressPaths = rpHttpIngressPaths.value
         val endpointName = name.value
 
         val magicEndpoints =
@@ -118,13 +118,13 @@ sealed trait LagomApp extends App {
 
       // Note: Play & Lagom need their endpoints defined first (see play-http-binding)
 
-      endpoints := {
+      rpEndpoints := {
         // We don't have any guarantees on plugin order between Play <-> Lagom so we check in both places
 
-        val current = endpoints.value.filterNot(_.name == "http")
+        val current = rpEndpoints.value.filterNot(_.name == "http")
 
         val lagom =
-          lagomRawEndpoints.value.zipWithIndex.map {
+          rpLagomRawEndpoints.value.zipWithIndex.map {
             case (e, 0) => e.withName("http")
             case (e, _) => e
           }
@@ -136,43 +136,43 @@ sealed trait LagomApp extends App {
 case object LagomJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings :+
-      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
+      (rpReactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
 }
 
 case object LagomScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings :+
-      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
+      (rpReactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
 }
 
 case object LagomPlayJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings :+
-      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
+      (rpReactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-java" -> true)
 }
 
 case object LagomPlayScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings :+
-      (reactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
+      (rpReactiveLibServiceDiscoveryProject := s"reactive-lib-service-discovery-lagom14-scala" -> true)
 }
 
 case object PlayApp extends App {
   def projectSettings: Seq[Setting[_]] =
     Vector(
-      appType := "play",
+      rpAppType := "play",
 
       // Note: Play & Lagom need their endpoints defined first (see play-http-binding)
 
-      enablePlayHttpBinding := true,
+      rpEnablePlayHttpBinding := true,
 
-      endpoints := {
+      rpEndpoints := {
         // We don't have any guarantees on plugin order between Play <-> Lagom so we check in both places
 
-        val current = endpoints.value
-        val paths = httpIngressPaths.value
-        val ports = httpIngressPorts.value
-        val hosts = httpIngressHosts.value
+        val current = rpEndpoints.value
+        val paths = rpHttpIngressPaths.value
+        val ports = rpHttpIngressPorts.value
+        val hosts = rpHttpIngressHosts.value
 
         if (current.exists(_.name == "http")) {
           current
@@ -190,77 +190,77 @@ case object PlayApp extends App {
 
 case object BasicApp extends DeployableApp {
   def globalSettings: Seq[Setting[_]] = Seq(
-    annotations := Map.empty)
+    rpAnnotations := Map.empty)
 
   def buildSettings: Seq[Setting[_]] =
     Vector(
-      deployMinikubeReactiveSandboxCqlStatements := Seq.empty,
-      helm := {
+      rpDeployMinikubeReactiveSandboxCqlStatements := Seq.empty,
+      rpHelm := {
         import complete.DefaultParsers._
         val args = spaceDelimited("<arg>").parsed
         cmd.helm.invoke(streams.value.log, args.toVector)
       },
-      kubectl := {
+      rpKubectl := {
         import complete.DefaultParsers._
         val args = spaceDelimited("<arg>").parsed
         cmd.kubectl.invoke(streams.value.log, args.toVector)
       },
-      minikube := {
+      rpMinikube := {
         import complete.DefaultParsers._
         val args = spaceDelimited("<arg>").parsed
         cmd.minikube.invoke(streams.value.log, args.toVector)
       },
-      aggregate in helm := false,
-      aggregate in kubectl := false,
-      aggregate in minikube := false)
+      aggregate in rpHelm := false,
+      aggregate in rpKubectl := false,
+      aggregate in rpMinikube := false)
 
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      alpinePackages := Vector.empty,
-      appName := name.value,
-      appType := "basic",
-      applications := Vector("default" -> Vector(s"bin/${executableScriptName.value}")),
-      cpu := 0.0D,
-      diskSpace := 0L,
-      memory := 0L,
-      enableCGroupMemoryLimit := true,
-      privileged := false,
-      runAsUser := "daemon",
-      runAsUserGroup := "",
-      runAsUserUID := -1,
-      runAsUserGID := -1,
-      environmentVariables := Map.empty,
-      startScriptLocation := "/rp-start",
-      secrets := Set.empty,
-      reactiveLibVersion := App.defaultReactiveLibVersion,
-      reactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
-      reactiveLibCommonProject := "reactive-lib-common" -> true,
-      reactiveLibPlayHttpBindingProject := "reactive-lib-play-http-binding" -> true,
-      reactiveLibSecretsProject := "reactive-lib-secrets" -> true,
-      reactiveLibServiceDiscoveryProject := "reactive-lib-service-discovery" -> true,
-      reactiveLibStatusProject := "reactive-lib-status" -> true,
-      requiredAlpinePackages := Vector("bash"),
-      enableAkkaClusterBootstrap := false,
-      enableAkkaManagement := enableAkkaClusterBootstrap.value || enableStatus.value,
-      enableCommon := true,
-      enablePlayHttpBinding := false,
-      enableSecrets := secrets.value.nonEmpty,
-      enableServiceDiscovery := enableAkkaClusterBootstrap.value,
-      enableStatus := enableAkkaClusterBootstrap.value,
+      rpAlpinePackages := Vector.empty,
+      rpAppName := name.value,
+      rpAppType := "basic",
+      rpApplications := Vector("default" -> Vector(s"bin/${executableScriptName.value}")),
+      rpCpu := 0.0D,
+      rpDiskSpace := 0L,
+      rpMemory := 0L,
+      rpEnableCGroupMemoryLimit := true,
+      rpPrivileged := false,
+      rpRunAsUser := "daemon",
+      rpRunAsUserGroup := "",
+      rpRunAsUserUID := -1,
+      rpRunAsUserGID := -1,
+      rpEnvironmentVariables := Map.empty,
+      rpStartScriptLocation := "/rp-start",
+      rpSecrets := Set.empty,
+      rpReactiveLibVersion := App.defaultReactiveLibVersion,
+      rpReactiveLibAkkaClusterBootstrapProject := "reactive-lib-akka-cluster-bootstrap" -> true,
+      rpReactiveLibCommonProject := "reactive-lib-common" -> true,
+      rpReactiveLibPlayHttpBindingProject := "reactive-lib-play-http-binding" -> true,
+      rpReactiveLibSecretsProject := "reactive-lib-secrets" -> true,
+      rpReactiveLibServiceDiscoveryProject := "reactive-lib-service-discovery" -> true,
+      rpReactiveLibStatusProject := "reactive-lib-status" -> true,
+      rpRequiredAlpinePackages := Vector("bash"),
+      rpEnableAkkaClusterBootstrap := false,
+      rpEnableAkkaManagement := rpEnableAkkaClusterBootstrap.value || rpEnableStatus.value,
+      rpEnableCommon := true,
+      rpEnablePlayHttpBinding := false,
+      rpEnableSecrets := rpSecrets.value.nonEmpty,
+      rpEnableServiceDiscovery := rpEnableAkkaClusterBootstrap.value,
+      rpEnableStatus := rpEnableAkkaClusterBootstrap.value,
 
-      prependRpConf := "application.conf",
+      rpPrependRpConf := "application.conf",
 
-      akkaClusterBootstrapEndpointName := "akka-remote",
+      rpAkkaClusterBootstrapEndpointName := "akka-remote",
 
-      akkaClusterBootstrapSystemName := "",
+      rpAkkaClusterBootstrapSystemName := "",
 
-      akkaManagementEndpointName := "akka-mgmt-http",
+      rpAkkaManagementEndpointName := "akka-mgmt-http",
 
-      httpIngressHosts := Seq.empty,
+      rpHttpIngressHosts := Seq.empty,
 
-      httpIngressPaths := Seq.empty,
+      rpHttpIngressPaths := Seq.empty,
 
-      httpIngressPorts := Seq(80, 443),
+      rpHttpIngressPorts := Seq(80, 443),
 
       resourceGenerators in Compile += Def.task {
         val outFile = (resourceManaged in Compile).value / "sbt-reactive-app" / LocalApplicationConfig
@@ -275,7 +275,7 @@ case object BasicApp extends DeployableApp {
             }
           }
 
-        val unmanagedConfigName = prependRpConf.value
+        val unmanagedConfigName = rpPrependRpConf.value
         if (unmanagedConfigName.isEmpty) Nil
         else {
           // 1. make the file under cache/sbt-reactive-app.
@@ -294,58 +294,58 @@ case object BasicApp extends DeployableApp {
 
       allDependencies :=
         allDependencies.value ++
-        lib(scalaVersion.value, reactiveLibAkkaClusterBootstrapProject.value, reactiveLibVersion.value, enableAkkaClusterBootstrap.value) ++
-        lib(scalaVersion.value, reactiveLibCommonProject.value, reactiveLibVersion.value, enableCommon.value) ++
-        lib(scalaVersion.value, reactiveLibPlayHttpBindingProject.value, reactiveLibVersion.value, enablePlayHttpBinding.value) ++
-        lib(scalaVersion.value, reactiveLibSecretsProject.value, reactiveLibVersion.value, enableSecrets.value) ++
-        lib(scalaVersion.value, reactiveLibServiceDiscoveryProject.value, reactiveLibVersion.value, enableServiceDiscovery.value) ++
-        lib(scalaVersion.value, reactiveLibStatusProject.value, reactiveLibVersion.value, enableStatus.value),
+        lib(scalaVersion.value, rpReactiveLibAkkaClusterBootstrapProject.value, rpReactiveLibVersion.value, rpEnableAkkaClusterBootstrap.value) ++
+        lib(scalaVersion.value, rpReactiveLibCommonProject.value, rpReactiveLibVersion.value, rpEnableCommon.value) ++
+        lib(scalaVersion.value, rpReactiveLibPlayHttpBindingProject.value, rpReactiveLibVersion.value, rpEnablePlayHttpBinding.value) ++
+        lib(scalaVersion.value, rpReactiveLibSecretsProject.value, rpReactiveLibVersion.value, rpEnableSecrets.value) ++
+        lib(scalaVersion.value, rpReactiveLibServiceDiscoveryProject.value, rpReactiveLibVersion.value, rpEnableServiceDiscovery.value) ++
+        lib(scalaVersion.value, rpReactiveLibStatusProject.value, rpReactiveLibVersion.value, rpEnableStatus.value),
 
-      endpoints := {
-        val clusterEndpointName = akkaClusterBootstrapEndpointName.value
-        val managementEndpointName = akkaManagementEndpointName.value
-        val bootstrapEnabled = enableAkkaClusterBootstrap.value
-        val managementEnabled = enableAkkaManagement.value
+      rpEndpoints := {
+        val clusterEndpointName = rpAkkaClusterBootstrapEndpointName.value
+        val managementEndpointName = rpAkkaManagementEndpointName.value
+        val bootstrapEnabled = rpEnableAkkaClusterBootstrap.value
+        val managementEnabled = rpEnableAkkaManagement.value
 
-        endpoints.?.value.getOrElse(Seq.empty) ++
+        rpEndpoints.?.value.getOrElse(Seq.empty) ++
           (if (bootstrapEnabled) Seq(TcpEndpoint(clusterEndpointName)) else Seq.empty) ++
           (if (managementEnabled) Seq(TcpEndpoint(managementEndpointName)) else Seq.empty)
       },
 
       javaOptions in SbtNativePackager.Universal ++= (
-        if (memory.value > 0L && enableCGroupMemoryLimit.value)
+        if (rpMemory.value > 0L && rpEnableCGroupMemoryLimit.value)
           Vector("-J-XX:+UnlockExperimentalVMOptions", "-J-XX:+UseCGroupMemoryLimitForHeap")
         else
           Vector.empty),
 
       dockerEntrypoint := (
-        if (startScriptLocation.value.isEmpty)
+        if (rpStartScriptLocation.value.isEmpty)
           dockerEntrypoint.value
         else
-          startScriptLocation.value +: dockerEntrypoint.value),
+          rpStartScriptLocation.value +: dockerEntrypoint.value),
 
       dockerBaseImage := "openjdk:8-jre-alpine",
 
       dockerEntrypoint := Vector.empty,
 
-      (daemonUser in Docker) := runAsUser.value,
-      (daemonGroup in Docker) := (if (runAsUserGroup.value.isEmpty) runAsUser.value else runAsUserGroup.value),
+      (daemonUser in Docker) := rpRunAsUser.value,
+      (daemonGroup in Docker) := (if (rpRunAsUserGroup.value.isEmpty) rpRunAsUser.value else rpRunAsUserGroup.value),
 
       dockerCommands := {
-        val bootstrapEnabled = enableAkkaClusterBootstrap.value
-        val bootstrapSystemName = Some(akkaClusterBootstrapSystemName.value).filter(_.nonEmpty && bootstrapEnabled)
-        val commonEnabled = enableCommon.value
-        val playHttpBindingEnabled = enablePlayHttpBinding.value
-        val secretsEnabled = enableSecrets.value
-        val serviceDiscoveryEnabled = enableServiceDiscovery.value
-        val statusEnabled = enableStatus.value
+        val bootstrapEnabled = rpEnableAkkaClusterBootstrap.value
+        val bootstrapSystemName = Some(rpAkkaClusterBootstrapSystemName.value).filter(_.nonEmpty && bootstrapEnabled)
+        val commonEnabled = rpEnableCommon.value
+        val playHttpBindingEnabled = rpEnablePlayHttpBinding.value
+        val secretsEnabled = rpEnableSecrets.value
+        val serviceDiscoveryEnabled = rpEnableServiceDiscovery.value
+        val statusEnabled = rpEnableStatus.value
         val akkaManagementEnabled = bootstrapEnabled || statusEnabled
         val rawDockerCommands = dockerCommands.value
-        val alpinePackagesValue = alpinePackages.value
-        val requiredAlpinePackagesValue = requiredAlpinePackages.value
+        val alpinePackagesValue = rpAlpinePackages.value
+        val requiredAlpinePackagesValue = rpRequiredAlpinePackages.value
         val allAlpinePackages = (alpinePackagesValue ++ requiredAlpinePackagesValue).distinct.sorted
         val dockerVersionValue = dockerVersion.value
-        val startScriptLocationValue = startScriptLocation.value
+        val startScriptLocationValue = rpStartScriptLocation.value
         val group = (daemonGroup in Docker).value
         val user = (daemonUser in Docker).value
 
@@ -355,8 +355,8 @@ case object BasicApp extends DeployableApp {
           else
             Vector(docker.Cmd("RUN", Vector("/sbin/apk", "add", "--no-cache") ++ allAlpinePackages: _*))
 
-        val uidFlag = if (runAsUserUID.value >= 0) s"-u ${runAsUserUID.value} " else ""
-        val gidFlag = if (runAsUserGID.value >= 0) s"-g ${runAsUserGID.value} " else ""
+        val uidFlag = if (rpRunAsUserUID.value >= 0) s"-u ${rpRunAsUserUID.value} " else ""
+        val gidFlag = if (rpRunAsUserGID.value >= 0) s"-g ${rpRunAsUserGID.value} " else ""
         val addUserCommands = Vector(
           docker.Cmd("RUN", s"id -g $group || addgroup ${gidFlag}$group"),
           docker.Cmd("RUN", s"id -u $user || adduser ${uidFlag}$user $group"))
@@ -384,9 +384,9 @@ case object BasicApp extends DeployableApp {
 
         rawAndPackageAndUserCommands ++ labelCommand(SbtReactiveApp
           .labels(
-            appName = Some(appName.value),
-            appType = Some(appType.value),
-            applications = applications.value.toVector.map {
+            appName = Some(rpAppName.value),
+            appType = Some(rpAppType.value),
+            applications = rpApplications.value.toVector.map {
               case (aName, appValue) =>
                 val script =
                   startScriptLocationValue
@@ -396,18 +396,18 @@ case object BasicApp extends DeployableApp {
 
                 aName -> args
             },
-            configResource = Some((prependRpConf in Compile).value)
+            configResource = Some((rpPrependRpConf in Compile).value)
               .filter(_.nonEmpty)
               .map(_ => LocalApplicationConfig),
-            diskSpace = if (diskSpace.value > 0L) Some(diskSpace.value) else None,
-            memory = if (memory.value > 0) Some(memory.value) else None,
-            cpu = if (cpu.value >= 0.0001D) Some(cpu.value) else None,
-            endpoints = endpoints.value.toVector,
-            privileged = privileged.value,
-            environmentVariables = environmentVariables.value,
+            diskSpace = if (rpDiskSpace.value > 0L) Some(rpDiskSpace.value) else None,
+            memory = if (rpMemory.value > 0) Some(rpMemory.value) else None,
+            cpu = if (rpCpu.value >= 0.0001D) Some(rpCpu.value) else None,
+            endpoints = rpEndpoints.value.toVector,
+            privileged = rpPrivileged.value,
+            environmentVariables = rpEnvironmentVariables.value,
             version = Some(Keys.version.value),
-            secrets = secrets.value,
-            annotations = annotations.value,
+            secrets = rpSecrets.value,
+            annotations = rpAnnotations.value,
             modules = Seq(
               "akka-cluster-bootstrapping" -> bootstrapEnabled,
               "akka-management" -> akkaManagementEnabled,

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/Deploy.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/Deploy.scala
@@ -34,29 +34,29 @@ trait DeployableApp extends App {
   private val reactiveSandboxInstalledLatch = new java.util.concurrent.CountDownLatch(1)
 
   def projectSettings: Seq[Setting[_]] = Vector(
-    deployMinikubeEnableReactiveSandbox := {
+    rpDeployMinikubeEnableReactiveSandbox := {
       val kafkaEnabled = SettingKey[Boolean]("lagomKafkaEnabled").?.value.getOrElse(false)
       val cassandraEnabled = SettingKey[Boolean]("lagomCassandraEnabled").?.value.getOrElse(false)
 
       kafkaEnabled || cassandraEnabled
     },
-    deployMinikubeReactiveSandboxExternalServices := Map(
+    rpDeployMinikubeReactiveSandboxExternalServices := Map(
       "cas_native" -> "_cql._tcp.reactive-sandbox-cassandra.default.svc.cluster.local",
       "kafka_native" -> "_broker._tcp.reactive-sandbox-kafka.default.svc.cluster.local",
       "elastic-search" -> "_http._tcp.reactive-sandbox-elasticsearch.default.svc.cluster.local"),
-    deployMinikubeAdditionalExternalServices := Map.empty,
-    deployMinikubeAkkaClusterBootstrapContactPoints := 1,
-    deployMinikubePlayHostAllowedProperty := "play.filters.hosts.allowed.0",
-    deployMinikubePlayHttpSecretKeyProperty := "play.http.secret.key",
-    deployMinikubePlayHttpSecretKeyValue := "dev-minikube",
-    deploy := {
+    rpDeployMinikubeAdditionalExternalServices := Map.empty,
+    rpDeployMinikubeAkkaClusterBootstrapContactPoints := 1,
+    rpDeployMinikubePlayHostAllowedProperty := "play.filters.hosts.allowed.0",
+    rpDeployMinikubePlayHttpSecretKeyProperty := "play.http.secret.key",
+    rpDeployMinikubePlayHttpSecretKeyValue := "dev-minikube",
+    rpDeploy := {
       import complete.DefaultParsers._
       import scala.sys.process._
 
       val args = spaceDelimited("<arg>").parsed
-      val isPlagom = Set("play", "lagom").contains(appType.value)
-      val bootstrapEnabled = enableAkkaClusterBootstrap.value
-      val reactiveSandbox = deployMinikubeEnableReactiveSandbox.value
+      val isPlagom = Set("play", "lagom").contains(rpAppType.value)
+      val bootstrapEnabled = rpEnableAkkaClusterBootstrap.value
+      val reactiveSandbox = rpDeployMinikubeEnableReactiveSandbox.value
 
       args.headOption.getOrElse("").trim.toLowerCase match {
         case "minikube" => {
@@ -81,7 +81,7 @@ trait DeployableApp extends App {
           cmd.rp.assert()
 
           if (reactiveSandbox) {
-            cmd.helm.assert();
+            cmd.helm.assert()
           }
 
           // This wrapper script that sets minikube environment before execing its args
@@ -157,15 +157,15 @@ trait DeployableApp extends App {
 
           val javaOpts =
             Vector(
-              if (isPlagom) s"-D${deployMinikubePlayHostAllowedProperty.value}=$minikubeIp" else "",
-              if (isPlagom) s"-D${deployMinikubePlayHttpSecretKeyProperty.value}=${deployMinikubePlayHttpSecretKeyValue.value}" else "")
+              if (isPlagom) s"-D${rpDeployMinikubePlayHostAllowedProperty.value}=$minikubeIp" else "",
+              if (isPlagom) s"-D${rpDeployMinikubePlayHttpSecretKeyProperty.value}=${rpDeployMinikubePlayHttpSecretKeyValue.value}" else "")
               .filterNot(_.isEmpty)
 
           val services =
             if (reactiveSandbox)
-              deployMinikubeReactiveSandboxExternalServices.value ++ deployMinikubeAdditionalExternalServices.value
+              rpDeployMinikubeReactiveSandboxExternalServices.value ++ rpDeployMinikubeAdditionalExternalServices.value
             else
-              deployMinikubeAdditionalExternalServices.value
+              rpDeployMinikubeAdditionalExternalServices.value
 
           val serviceArgs =
             services.flatMap {
@@ -178,9 +178,9 @@ trait DeployableApp extends App {
               dockerAlias.value.versioned,
               "--env",
               s"JAVA_OPTS=${javaOpts.mkString(" ")}") ++
-              (if (bootstrapEnabled) Vector("--akka-cluster-skip-validation", "--pod-controller-replicas", deployMinikubeAkkaClusterBootstrapContactPoints.value.toString) else Vector.empty) ++
+              (if (bootstrapEnabled) Vector("--akka-cluster-skip-validation", "--pod-controller-replicas", rpDeployMinikubeAkkaClusterBootstrapContactPoints.value.toString) else Vector.empty) ++
               serviceArgs ++
-              deployMinikubeRpArguments.value
+              rpDeployMinikubeRpArguments.value
 
           publishLocalDocker(
             (stage in Docker).value,
@@ -200,7 +200,7 @@ trait DeployableApp extends App {
             if (shouldInstallReactiveSandbox) {
               for {
                 pod <- cmd.kubectl.getPodNames("app=reactive-sandbox")
-                statement <- (deployMinikubeReactiveSandboxCqlStatements in ThisBuild).value
+                statement <- (rpDeployMinikubeReactiveSandboxCqlStatements in ThisBuild).value
               } {
                 log.info(s"executing cassandra cql: $statement")
 
@@ -222,5 +222,5 @@ trait DeployableApp extends App {
           sys.error(s"""Unknown deployment target: "$other". Available: minikube""")
       }
     },
-    deployMinikubeRpArguments := Seq.empty)
+    rpDeployMinikubeRpArguments := Seq.empty)
 }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -23,182 +23,182 @@ trait SbtReactiveAppKeys {
    * Defines the application name. This defaults to the project name and is used in naming services. On Kubernetes,
    * this gets used for the `Service` name (after being scrubbed according to service name logic)
    */
-  val appName = TaskKey[String]("rp-app-name")
+  val rpAppName = taskKey[String]("")
 
   /**
    * Defines the application type - this is currently one of lagom, play, or basic. It's used internally and not
    * intended to be overridden.
    */
-  val appType = SettingKey[String]("rp-app-type")
+  val rpAppType = settingKey[String]("")
 
   /**
    * Defines the optional disk space requirement for scheduling this application.
    */
-  val diskSpace = SettingKey[Long]("rp-disk-space")
+  val rpDiskSpace = settingKey[Long]("")
 
   /**
    * Defines the optional memory requirement for scheduling this application. Defaults to 0, i.e. disabled.
    */
-  val memory = SettingKey[Long]("rp-memory")
+  val rpMemory = settingKey[Long]("")
 
   /**
    * If true, `memory` setting will set CGroup limits for the JVM in addition to platform (eg. Kubernetes) limits.
    * If false, only platform limits will be enforced. Default is true.
    */
-  val enableCGroupMemoryLimit = SettingKey[Boolean]("rp-enable-cgroup-memory-limit")
+  val rpEnableCGroupMemoryLimit = settingKey[Boolean]("")
 
   /**
    * Defines the optional CPU share requirement for scheduling this application. This follows Mesos conventions, so
    * for CGroup shares this value is multiplied by 1024. A reasonable starting value is 0.1. Defaults to 0, i.e.
    * disabled.
    */
-  val cpu = SettingKey[Double]("rp-cpu")
+  val rpCpu = settingKey[Double]("")
 
   /**
    * Defines the endpoints for this application. On Kubernetes, Services will be created for each endpoint, and if
    * the endpoint specifies Ingress then it will be generated as well.
    */
-  val endpoints = TaskKey[Seq[Endpoint]]("rp-endpoints")
+  val rpEndpoints = taskKey[Seq[Endpoint]]("")
 
   /**
    * If true, the container should be run in a privileged setting, i.e. with root privileges.
    */
-  val privileged = SettingKey[Boolean]("rp-privileged")
+  val rpPrivileged = settingKey[Boolean]("")
 
   /**
    * Run application as the given user. Defaults to `daemon`.
    */
-  val runAsUser = SettingKey[String]("rp-run-as-user", "Run application as the given user. Defaults to `daemon`.")
+  val rpRunAsUser = settingKey[String]("Run application as the given user. Defaults to `daemon`.")
 
   /**
    * Group that the user belongs to. Defaults to the user name.
    */
-  val runAsUserGroup = SettingKey[String]("rp-run-as-user-group", "Group that the user belongs to. Defaults to the user name.")
+  val rpRunAsUserGroup = settingKey[String]("Group that the user belongs to. Defaults to the user name.")
 
   /**
    * UID of the user.
    */
-  val runAsUserUID = SettingKey[Int]("rp-run-as-user-uid", "UID of the user.")
+  val rpRunAsUserUID = settingKey[Int]("UID of the user.")
 
   /**
    * GID of the user's group.
    */
-  val runAsUserGID = SettingKey[Int]("rp-run-as-user-gid", "GID of the user's group.")
+  val rpRunAsUserGID = settingKey[Int]("GID of the user's group.")
 
   /**
    * Defines the endpoint name for the akka remoting port. reactive-lib expects the default values here so you
    * should not have to change this under normal circumstances.
    */
-  val akkaClusterBootstrapEndpointName = SettingKey[String]("rp-akka-cluster-bootstrap-endpoint-name")
+  val rpAkkaClusterBootstrapEndpointName = settingKey[String]("")
 
   /**
    * If specified, app will join other nodes that specify this same system name. This can be used to allow different
    * applications to join the same cluster. If empty (default), the default logic of using the appName will be
    * used instead.
    */
-  val akkaClusterBootstrapSystemName = SettingKey[String]("rp-akka-cluster-bootstrap-system-name")
+  val rpAkkaClusterBootstrapSystemName = settingKey[String]("")
 
   /**
    * Defines the endpoint name for the akka management port. reactive-lib expects the default values here so you
    * should not have to change this under normal circumstances.
    */
-  val akkaManagementEndpointName = SettingKey[String]("rp-akka-management-endpoint-name")
+  val rpAkkaManagementEndpointName = settingKey[String]("")
 
   /**
    * Defines packages to install on top of the base alpine image.
    */
-  val alpinePackages = SettingKey[Seq[String]]("rp-alpine-packages")
+  val rpAlpinePackages = settingKey[Seq[String]]("")
 
   /**
    * Defines the available applications. This is a list of appName -> appArgs. The operator can specify alternate
    * applications to dynamically override the command/arguments that are executed.
    */
-  val applications = TaskKey[Seq[(String, Seq[String])]]("rp-applications")
+  val rpApplications = taskKey[Seq[(String, Seq[String])]]("")
 
   /**
    * This task deploys all aggregated projects into a target environment. Currently, minikube is supported.
    */
-  val deploy = InputKey[Unit]("deploy")
+  val rpDeploy = inputKey[Unit]("")
 
   /**
    * A map of service names to service lookup addresses. This will be provided as an argument to rp for resources
    * are are generated when running deploy minikube. Note that this map will only be added if reactive sandbox is
    * enabled.
    */
-  val deployMinikubeReactiveSandboxExternalServices = SettingKey[Map[String, String]]("rp-deploy-minikube-reactive-sandbox-external-services")
+  val rpDeployMinikubeReactiveSandboxExternalServices = settingKey[Map[String, String]]("")
 
   /**
    * An additional map of service names to service lookup addresses. These will always be provided to rp and take
    * precedence over the Reactive Sandbox addresses.
    */
-  val deployMinikubeAdditionalExternalServices = SettingKey[Map[String, String]]("rp-deploy-minikube-additional-external-services")
+  val rpDeployMinikubeAdditionalExternalServices = settingKey[Map[String, String]]("")
 
   /**
    * When deploying applications with Akka Cluster Bootstrap enabled, the services will initially be started with this
    * many contact points / replicas.
    */
-  val deployMinikubeAkkaClusterBootstrapContactPoints = SettingKey[Int]("rp-deploy-minikube-akka-cluster-bootstrap-contact-points")
+  val rpDeployMinikubeAkkaClusterBootstrapContactPoints = settingKey[Int]("")
 
   /**
    * If enabled, Reactive Sandbox (a Docker image containing Cassandra, Kafka, ZooKeeper, Elasticsearch) will be
    * deployed with this app.
    */
-  val deployMinikubeEnableReactiveSandbox = SettingKey[Boolean]("rp-deploy-minikube-enable-reactive-sandbox")
+  val rpDeployMinikubeEnableReactiveSandbox = settingKey[Boolean]("")
 
   /**
    * If deploying a Play application, this property will be set to the Minikube IP.
    */
-  val deployMinikubePlayHostAllowedProperty = SettingKey[String]("rp-deploy-minikube-play-host-allowed-property")
+  val rpDeployMinikubePlayHostAllowedProperty = settingKey[String]("")
 
   /**
    * If deploying a Play application, this property will be set to the value specified below.
    */
-  val deployMinikubePlayHttpSecretKeyProperty = SettingKey[String]("rp-deploy-minikube-play-http-secret-key-property")
+  val rpDeployMinikubePlayHttpSecretKeyProperty = settingKey[String]("")
 
   /**
    * If deploying a Play application, this property will be set to the value specified above.
    */
-  val deployMinikubePlayHttpSecretKeyValue = SettingKey[String]("rp-deploy-minikube-play-http-secret-key-value")
+  val rpDeployMinikubePlayHttpSecretKeyValue = settingKey[String]("")
 
   /**
    * Set this setting (build-wide, i.e. deployMinikubeReactiveSandboxCqlStatements in ThisBuild := ...) to a sequence
    * of CQL statements that should be executed against Cassandra when the Reactive Sandbox is installed.
    */
-  val deployMinikubeReactiveSandboxCqlStatements = SettingKey[Seq[String]]("rp-deploy-minikube-reactive-sandbox-cql-statements")
+  val rpDeployMinikubeReactiveSandboxCqlStatements = settingKey[Seq[String]]("")
 
   /**
    * Additional arguments to invoke rp with for this app.
    */
-  val deployMinikubeRpArguments = SettingKey[Seq[String]]("rp-deploy-minikube-rp-arguments")
+  val rpDeployMinikubeRpArguments = settingKey[Seq[String]]("")
 
   /**
    * For endpoints that are autopopulated, they will declare ingress for these hosts. That is, they'll be available
    * on the public nodes or ingress controllers at these hostnames. Defaults to nothing for Basic apps, "/" for Play
    * apps, and the collection of service endpoints for Lagom apps.
    */
-  val httpIngressHosts = SettingKey[Seq[String]]("rp-ingress-hosts")
+  val rpHttpIngressHosts = settingKey[Seq[String]]("")
 
   /**
    * For endpoints that are autopopulated, they will declare ingress for these hosts. That is, they'll be available
    * on the public nodes or ingress controllers at these hostnames.
    */
-  val httpIngressPaths = TaskKey[Seq[String]]("rp-ingress-paths")
+  val rpHttpIngressPaths = taskKey[Seq[String]]("")
 
   /**
    * For endpoints that are autopopulated, they will declare ingress for these posts. That is, they'll be available
    * on the public nodes or ingress controllers at these posts. Defaults to 80 and 443.
    */
-  val httpIngressPorts = SettingKey[Seq[Int]]("rp-ingress-ports")
+  val rpHttpIngressPorts = settingKey[Seq[Int]]("")
 
   /**
    * Defines environment variable values that this application should be run with at runtime.
    */
-  val environmentVariables = SettingKey[Map[String, EnvironmentVariable]]("rp-environment-variables")
+  val rpEnvironmentVariables = settingKey[Map[String, EnvironmentVariable]]("")
 
   /**
    * Enables Akka Cluster Bootstrapping (reactive-lib).
    */
-  val enableAkkaClusterBootstrap = TaskKey[Boolean]("rp-enable-akka-cluster-bootstrap", "Include Akka Cluster Bootstrapping. By default, included if a Lagom persistence module is defined.")
+  val rpEnableAkkaClusterBootstrap = taskKey[Boolean]("Include Akka Cluster Bootstrapping. By default, included if a Lagom persistence module is defined.")
 
   /**
    * Enables Akka Management (reactive-lib).
@@ -207,31 +207,31 @@ trait SbtReactiveAppKeys {
    *   - akka-cluster-bootstrap
    *   - status
    */
-  val enableAkkaManagement = TaskKey[Boolean]("rp-enable-akka-management")
+  val rpEnableAkkaManagement = taskKey[Boolean]("")
 
   /**
    * Enables the common library (reactive-lib). This defaults to true. It provides a few APIs that the application
    * is using to determine what target platform its running on, what ports it should bind on, etc.
    */
-  val enableCommon = TaskKey[Boolean]("rp-enable-common")
+  val rpEnableCommon = taskKey[Boolean]("")
 
   /**
    * Enable the Play HTTP binding library (reactive-lib). This is enabled by default for Lagom and Play projects and
    * allows the tooling to automatically assign ports.
    */
-  val enablePlayHttpBinding = TaskKey[Boolean]("rp-enable-play-http-binding")
+  val rpEnablePlayHttpBinding = taskKey[Boolean]("")
 
   /**
    * Enable the secret library (reactive-lib). By default, it will automatically be enabled if any secrets are
    * declared.
    */
-  val enableSecrets = TaskKey[Boolean]("rp-enable-secrets", "Include Secrets API. By default, included if any secrets are defined.")
+  val rpEnableSecrets = taskKey[Boolean]("Include Secrets API. By default, included if any secrets are defined.")
 
   /**
    * Enables the service discovery library (reactive-lib). If enabled, a service locator API will be on the classpath
    * and for Lagom projects, an implementation of Lagom's service locator will be provided.
    */
-  val enableServiceDiscovery = TaskKey[Boolean]("rp-enable-service-discovery")
+  val rpEnableServiceDiscovery = taskKey[Boolean]("")
 
   /**
    * Enables the status library (reactive-lib). By default, it will automatically be enabled if any modules
@@ -239,79 +239,164 @@ trait SbtReactiveAppKeys {
    * routes for health and readiness will be added to the Akka Management HTTP server, and at resource generation
    * the appropriate health/readiness configuration will be generated to monitor these endpoints.
    */
-  val enableStatus = TaskKey[Boolean]("rp-enable-status")
+  val rpEnableStatus = taskKey[Boolean]("")
 
   /**
    * Executes `helm` program with any specified arguments. This may be expanded to support auto completion in
    * the future.
    */
-  val helm = InputKey[Unit]("helm")
+  val rpHelm = inputKey[Unit]("")
 
   /**
    * Executes `kubectl` program with any specified arguments. This may be expanded to support auto completion in
    * the future.
    */
-  val kubectl = InputKey[Unit]("kubectl")
+  val rpKubectl = inputKey[Unit]("")
 
   /**
    * Executes `minikube` program with any specified arguments. This may be expanded to support auto completion in
    * the future.
    */
-  val minikube = InputKey[Unit]("minikube")
+  val rpMinikube = inputKey[Unit]("")
 
   /**
    * If non-empty (default: "application.conf"), all unmanaged resources with the given name, in any dependencies,
    * as well as all managed resources named "rp-tooling.conf'",
    * will be concatenated into a managed resource "rp-application.conf" file. To disable this behavior, specify "".
    */
-  val prependRpConf = SettingKey[String]("rp-prepend-rp-application-conf")
+  val rpPrependRpConf = settingKey[String]("")
 
   /**
    * Defines the published reactive-lib version to include in the project. You can set this value to upgrade
    * reactive-lib without having to update sbt-reactive-app.
    */
-  val reactiveLibVersion = SettingKey[String]("rp-reactive-lib-version")
+  val rpReactiveLibVersion = settingKey[String]("")
 
   /**
    * Defines location where the wrapper script for app execution should be placed (in the container). If empty,
    * no wrapper script is used.
    */
-  val startScriptLocation = SettingKey[String]("rp-start-script")
+  val rpStartScriptLocation = settingKey[String]("")
 
   /**
    * Defines secrets that will be made available to the application at runtime. The secrets API in reactive-lib
    * can then be used to decode these secrets in a consistent and platform-independent manner.
    */
-  val secrets = SettingKey[Set[Secret]]("rp-secrets")
+  val rpSecrets = settingKey[Set[Secret]]("")
 
   /**
    * Annotations to attach to the application at runtime. On Kubernetes, this will become a pod annotation. On
    * DC/OS it will be a label.
    */
-  val annotations = TaskKey[Map[String, String]](
-    "rp-annotations",
+  val rpAnnotations = taskKey[Map[String, String]](
     "Annotations to attach to the application at runtime. On Kubernetes, this will become a pod annotation. " +
       "On DC/OS it will be a label.")
 
-  private[sbtreactiveapp] val deployMinikubeDockerEnv = TaskKey[String]("rp-deploy-minikube-docker-env")
+  private[sbtreactiveapp] val rpDeployMinikubeDockerEnv = taskKey[String]("")
 
-  private[sbtreactiveapp] val lagomRawEndpoints = TaskKey[Seq[Endpoint]]("rp-lagom-raw-endpoints")
+  private[sbtreactiveapp] val rpLagomRawEndpoints = taskKey[Seq[Endpoint]]("")
 
-  private[sbtreactiveapp] val reactiveLibAkkaClusterBootstrapProject = SettingKey[(String, Boolean)]("rp-reactive-lib-akka-cluster-bootstrap-project")
-
-  private[sbtreactiveapp] val reactiveLibCommonProject = SettingKey[(String, Boolean)]("rp-reactive-lib-common-project")
-
-  private[sbtreactiveapp] val reactiveLibPlayHttpBindingProject = SettingKey[(String, Boolean)]("rp-reactive-lib-play-http-binding-project")
-
-  private[sbtreactiveapp] val reactiveLibSecretsProject = SettingKey[(String, Boolean)]("rp-reactive-lib-secrets-project")
-
-  private[sbtreactiveapp] val reactiveLibServiceDiscoveryProject = SettingKey[(String, Boolean)]("rp-reactive-lib-service-discovery-project")
-
-  private[sbtreactiveapp] val reactiveLibStatusProject = SettingKey[(String, Boolean)]("rp-reactive-lib-status-project")
+  private[sbtreactiveapp] val rpReactiveLibAkkaClusterBootstrapProject = settingKey[(String, Boolean)]("")
+  private[sbtreactiveapp] val rpReactiveLibCommonProject = settingKey[(String, Boolean)]("")
+  private[sbtreactiveapp] val rpReactiveLibPlayHttpBindingProject = settingKey[(String, Boolean)]("")
+  private[sbtreactiveapp] val rpReactiveLibSecretsProject = settingKey[(String, Boolean)]("")
+  private[sbtreactiveapp] val rpReactiveLibServiceDiscoveryProject = settingKey[(String, Boolean)]("")
+  private[sbtreactiveapp] val rpReactiveLibStatusProject = settingKey[(String, Boolean)]("")
 
   /**
-   * Defines alpine packages that are installed (and required) by this plugin. This is combined with the user-defined
-   * packages (`alpinePackages`).
+   * Defines alpine packages that are installed (and required) by this plugin.
+   * This is combined with the user-defined packages (`alpinePackages`).
    */
-  private[sbtreactiveapp] val requiredAlpinePackages = SettingKey[Seq[String]]("rp-required-alpine-packages")
+  private[sbtreactiveapp] val rpRequiredAlpinePackages = settingKey[Seq[String]]("")
+
+  @deprecated("use rpAppName", "1.5.0") val appName = rpAppName
+  @deprecated("use rpAppType", "1.5.0") val appType = rpAppType
+  @deprecated("use rpDiskSpace", "1.5.0") val diskSpace = rpDiskSpace
+  @deprecated("use rpMemory", "1.5.0") val memory = rpMemory
+
+  @deprecated("use rpEnableCGroupMemoryLimit", "1.5.0")
+  val enableCGroupMemoryLimit = rpEnableCGroupMemoryLimit
+
+  @deprecated("use rpCpu", "1.5.0") val cpu = rpCpu
+  @deprecated("use rpEndpoints", "1.5.0") val endpoints = rpEndpoints
+  @deprecated("use rpPrivileged", "1.5.0") val privileged = rpPrivileged
+  @deprecated("use rpRunAsUser", "1.5.0") val runAsUser = rpRunAsUser
+  @deprecated("use rpRunAsUserGroup", "1.5.0") val runAsUserGroup = rpRunAsUserGroup
+  @deprecated("use rpRunAsUserUID", "1.5.0") val runAsUserUID = rpRunAsUserUID
+  @deprecated("use rpRunAsUserGID", "1.5.0") val runAsUserGID = rpRunAsUserGID
+
+  @deprecated("use rpAkkaClusterBootstrapEndpointName", "1.5.0")
+  val akkaClusterBootstrapEndpointName = rpAkkaClusterBootstrapEndpointName
+
+  @deprecated("use rpAkkaClusterBootstrapSystemName", "1.5.0")
+  val akkaClusterBootstrapSystemName = rpAkkaClusterBootstrapSystemName
+
+  @deprecated("use rpAkkaManagementEndpointName", "1.5.0")
+  val akkaManagementEndpointName = rpAkkaManagementEndpointName
+
+  @deprecated("use rpAlpinePackages", "1.5.0") val alpinePackages = rpAlpinePackages
+  @deprecated("use rpApplications", "1.5.0") val applications = rpApplications
+  @deprecated("use rpDeploy", "1.5.0") val deploy = rpDeploy
+
+  @deprecated("use rpDeployMinikubeReactiveSandboxExternalServices", "1.5.0")
+  val deployMinikubeReactiveSandboxExternalServices = rpDeployMinikubeReactiveSandboxExternalServices
+
+  @deprecated("use rpDeployMinikubeAdditionalExternalServices", "1.5.0")
+  val deployMinikubeAdditionalExternalServices = rpDeployMinikubeAdditionalExternalServices
+
+  @deprecated("use rpDeployMinikubeAkkaClusterBootstrapContactPoints", "1.5.0")
+  val deployMinikubeAkkaClusterBootstrapContactPoints = rpDeployMinikubeAkkaClusterBootstrapContactPoints
+
+  @deprecated("use rpDeployMinikubeEnableReactiveSandbox", "1.5.0")
+  val deployMinikubeEnableReactiveSandbox = rpDeployMinikubeEnableReactiveSandbox
+
+  @deprecated("use rpDeployMinikubePlayHostAllowedProperty", "1.5.0")
+  val deployMinikubePlayHostAllowedProperty = rpDeployMinikubePlayHostAllowedProperty
+
+  @deprecated("use rpDeployMinikubePlayHttpSecretKeyProperty", "1.5.0")
+  val deployMinikubePlayHttpSecretKeyProperty = rpDeployMinikubePlayHttpSecretKeyProperty
+
+  @deprecated("use rpDeployMinikubePlayHttpSecretKeyValue", "1.5.0")
+  val deployMinikubePlayHttpSecretKeyValue = rpDeployMinikubePlayHttpSecretKeyValue
+
+  @deprecated("use rpDeployMinikubeReactiveSandboxCqlStatements", "1.5.0")
+  val deployMinikubeReactiveSandboxCqlStatements = rpDeployMinikubeReactiveSandboxCqlStatements
+
+  @deprecated("use rpDeployMinikubeRpArguments", "1.5.0")
+  val deployMinikubeRpArguments = rpDeployMinikubeRpArguments
+
+  @deprecated("use rpHttpIngressHosts", "1.5.0") val httpIngressHosts = rpHttpIngressHosts
+  @deprecated("use rpHttpIngressPaths", "1.5.0") val httpIngressPaths = rpHttpIngressPaths
+  @deprecated("use rpHttpIngressPorts", "1.5.0") val httpIngressPorts = rpHttpIngressPorts
+  @deprecated("use rpEnvironmentVariables", "1.5.0") val environmentVariables = rpEnvironmentVariables
+
+  @deprecated("use rpEnableAkkaClusterBootstrap", "1.5.0")
+  val enableAkkaClusterBootstrap = rpEnableAkkaClusterBootstrap
+
+  @deprecated("use rpEnableAkkaManagement", "1.5.0")
+  val enableAkkaManagement = rpEnableAkkaManagement
+
+  @deprecated("use rpEnableCommon", "1.5.0")
+  val enableCommon = rpEnableCommon
+
+  @deprecated("use rpEnablePlayHttpBinding", "1.5.0")
+  val enablePlayHttpBinding = rpEnablePlayHttpBinding
+
+  @deprecated("use rpEnableSecrets", "1.5.0")
+  val enableSecrets = rpEnableSecrets
+
+  @deprecated("use rpEnableServiceDiscovery", "1.5.0")
+  val enableServiceDiscovery = rpEnableServiceDiscovery
+
+  @deprecated("use rpEnableStatus", "1.5.0")
+  val enableStatus = rpEnableStatus
+
+  @deprecated("use rpHelm", "1.5.0") val helm = rpHelm
+  @deprecated("use rpKubectl", "1.5.0") val kubectl = rpKubectl
+  @deprecated("use rpMinikube", "1.5.0") val minikube = rpMinikube
+  @deprecated("use rpPrependRpConf", "1.5.0") val prependRpConf = rpPrependRpConf
+  @deprecated("use rpReactiveLibVersion", "1.5.0") val reactiveLibVersion = rpReactiveLibVersion
+  @deprecated("use rpStartScriptLocation", "1.5.0") val startScriptLocation = rpStartScriptLocation
+  @deprecated("use rpSecrets", "1.5.0") val secrets = rpSecrets
+  @deprecated("use rpAnnotations", "1.5.0") val annotations = rpAnnotations
 }

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-bootstrapping-adds-endpoint/build.sbt
@@ -4,12 +4,12 @@ scalaVersion := "2.11.11"
 
 enablePlugins(SbtReactiveAppPlugin)
 
-enableAkkaClusterBootstrap := true
+rpEnableAkkaClusterBootstrap := true
 
-akkaClusterBootstrapEndpointName := "my-akka-remote"
+rpAkkaClusterBootstrapEndpointName := "my-akka-remote"
 
 TaskKey[Unit]("check") := {
-  assert(endpoints.value.contains(TcpEndpoint("my-akka-remote", 0)))
+  assert(rpEndpoints.value.contains(TcpEndpoint("my-akka-remote", 0)))
 
   val outputDir = (stage in Docker).value
   val contents = IO.read(outputDir / "Dockerfile")

--- a/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/build.sbt
@@ -12,8 +12,8 @@ lazy val root = (project in file("."))
     ),
 
     packageName in Docker := "hello-akka",
-    enableAkkaClusterBootstrap := true,
-    akkaClusterBootstrapSystemName := "ClusterSystem"
+    rpEnableAkkaClusterBootstrap := true,
+    rpAkkaClusterBootstrapSystemName := "ClusterSystem"
   )
 
 TaskKey[Unit]("check") := {

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
@@ -2,7 +2,7 @@ name := "alpine-packages"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-alpinePackages += "coreutils"
+rpAlpinePackages += "coreutils"
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/cgroups-memory-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/cgroups-memory-disabled/build.sbt
@@ -5,8 +5,8 @@ scalaVersion := "2.11.11"
 
 enablePlugins(SbtReactiveAppPlugin)
 
-memory := 1048576
-enableCGroupMemoryLimit := false
+rpMemory := 1048576
+rpEnableCGroupMemoryLimit := false
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/cgroups-memory-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/cgroups-memory-enabled/build.sbt
@@ -3,8 +3,8 @@ scalaVersion := "2.11.11"
 
 enablePlugins(SbtReactiveAppPlugin)
 
-memory := 1048576
-enableCGroupMemoryLimit := true
+rpMemory := 1048576
+rpEnableCGroupMemoryLimit := true
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/detection/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/detection/build.sbt
@@ -29,7 +29,7 @@ lazy val frontend = (project in file("frontend"))
 lazy val `frontend-play` = (project in file("frontend-play"))
   .enablePlugins(PlayScala, SbtReactiveAppPlugin)
   .settings(
-    enableServiceDiscovery := true,
+    rpEnableServiceDiscovery := true,
     libraryDependencies ++= Seq(
       guice, // This is required to configure Play's application loader
       ws
@@ -63,27 +63,27 @@ lazy val `lagom-java-impl` = (project in file("lagom-java-impl"))
 
 TaskKey[Unit]("checkAppType") := {
   assert(
-    (appType in `simple-app`).value == "basic",
+    (rpAppType in `simple-app`).value == "basic",
     s"Incorrect appType for ${(name in `simple-app`).value}: ${(appType in `simple-app`).value}"
   )
 
   assert(
-    (appType in `frontend-play`).value == "play",
+    (rpAppType in `frontend-play`).value == "play",
     s"Incorrect appType for ${(name in `frontend-play`).value}: ${(appType in `frontend-play`).value}"
   )
 
   assert(
-    (appType in frontend).value == "lagom",
+    (rpAppType in frontend).value == "lagom",
     s"Incorrect appType for ${(name in frontend).value}: ${(appType in frontend).value}"
   )
 
   assert(
-    (appType in `lagom-java-impl`).value == "lagom",
+    (rpAppType in `lagom-java-impl`).value == "lagom",
     s"Incorrect appType for ${(name in `lagom-java-impl`).value}: ${(appType in `lagom-java-impl`).value}"
   )
 
   assert(
-    (appType in `lagom-scala-impl`).value == "lagom",
+    (rpAppType in `lagom-scala-impl`).value == "lagom",
     s"Incorrect appType for ${(name in `lagom-scala-impl`).value}: ${(appType in `lagom-scala-impl`).value}"
   )
 }
@@ -94,10 +94,10 @@ TaskKey[Unit]("checkServiceDiscoveryLibraries") := {
       left.name == right.name &&
       left.revision == right.revision
 
-  val rpCommon: ModuleID = "com.lightbend.rp" %% "reactive-lib-common" % (reactiveLibVersion in `simple-app`).value
-  val rpLagomServiceLocatorJava: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery-lagom14-java" % (reactiveLibVersion in `lagom-java-impl`).value
-  val rpLagomServiceLocatorScala: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery-lagom14-scala" % (reactiveLibVersion in `lagom-scala-impl`).value
-  val rpServiceLocator: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery" % (reactiveLibVersion in `frontend-play`).value
+  val rpCommon: ModuleID = "com.lightbend.rp" %% "reactive-lib-common" % (rpReactiveLibVersion in `simple-app`).value
+  val rpLagomServiceLocatorJava: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery-lagom14-java" % (rpReactiveLibVersion in `lagom-java-impl`).value
+  val rpLagomServiceLocatorScala: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery-lagom14-scala" % (rpReactiveLibVersion in `lagom-scala-impl`).value
+  val rpServiceLocator: ModuleID = "com.lightbend.rp" %% "reactive-lib-service-discovery" % (rpReactiveLibVersion in `frontend-play`).value
 
   val simpleAppLibs = (allDependencies in `simple-app`).value
   val frontendLibs = (allDependencies in frontend).value

--- a/src/sbt-test/sbt-reactive-app/export-annotations/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/build.sbt
@@ -2,7 +2,7 @@ name := "export-annotations"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-annotations := Map("es.lightbend.com/scrape" -> "true",
+rpAnnotations := Map("es.lightbend.com/scrape" -> "true",
                    "es.lightbend.com/port" -> "metrics",
                    "es.lightbend.com/path" -> "/metrics")
 

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -4,15 +4,15 @@ scalaVersion := "2.12.4"
 
 enablePlugins(SbtReactiveAppPlugin)
 
-cpu := 0.5
-memory := 65536
-diskSpace := 32768
-privileged := true
-endpoints := Vector(HttpEndpoint("test1", 2551, HttpIngress(ingressPorts = Seq(80, 443), hosts = Seq("hi.com"), paths = Seq("/test.*$"))))
-environmentVariables := Map(
+rpCpu := 0.5
+rpMemory := 65536
+rpDiskSpace := 32768
+rpPrivileged := true
+rpEndpoints := Vector(HttpEndpoint("test1", 2551, HttpIngress(ingressPorts = Seq(80, 443), hosts = Seq("hi.com"), paths = Seq("/test.*$"))))
+rpEnvironmentVariables := Map(
   "LD_LIBRARY_PATH" -> LiteralEnvironmentVariable("/lib"),
   "HOME" -> LiteralEnvironmentVariable("/home/testing"))
-secrets := Set(Secret("myns1", "key"), Secret("myns2", "otherkey"))
+rpSecrets := Set(Secret("myns1", "key"), Secret("myns2", "otherkey"))
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/build.sbt
@@ -26,7 +26,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-lagom",
-    httpIngressPorts := scala.collection.immutable.Seq(9000),
+    rpHttpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.read(outputDir / "Dockerfile")
@@ -63,7 +63,7 @@ lazy val `echo-impl` = (project in file("echo-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "echo-lagom",
-    httpIngressPorts := scala.collection.immutable.Seq(9000),
+    rpHttpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.readLines(outputDir / "Dockerfile")

--- a/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
@@ -7,8 +7,8 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-play",
-    httpIngressPorts := Seq(9000),
-    httpIngressPaths := Seq("/")
+    rpHttpIngressPorts := Seq(9000),
+    rpHttpIngressPaths := Seq("/")
   )
 
 TaskKey[Unit]("check") := {

--- a/src/sbt-test/sbt-reactive-app/prepend-rp-conf-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/prepend-rp-conf-disabled/build.sbt
@@ -3,7 +3,7 @@ scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
 // Disable creation of rp-application.conf.
-prependRpConf := ""
+rpPrependRpConf := ""
 
 // Add a few dependencies that contain rp-tooling.conf.
 libraryDependencies += "com.lightbend.rp" % "reactive-lib-status_2.12" % "0.7.0"

--- a/src/sbt-test/sbt-reactive-app/prepend-rp-conf/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/prepend-rp-conf/build.sbt
@@ -2,7 +2,7 @@ name := "prepend-rp-conf"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-prependRpConf := "application.conf"
+rpPrependRpConf := "application.conf"
 
 // Add a few dependencies that contain rp-tooling.conf.
 libraryDependencies += "com.lightbend.rp" % "reactive-lib-status_2.12" % "0.7.0"

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/build.sbt
@@ -2,10 +2,10 @@ name := "run-as-use-group-uid-gid"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-runAsUser := "rpuser"
-runAsUserGroup := "rpgroup"
-runAsUserUID := 50
-runAsUserGID := 60
+rpRunAsUser := "rpuser"
+rpRunAsUserGroup := "rpgroup"
+rpRunAsUserUID := 50
+rpRunAsUserGID := 60
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/run-as-user/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/build.sbt
@@ -2,7 +2,7 @@ name := "run-as-user"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-runAsUser := "rpuser"
+rpRunAsUser := "rpuser"
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-disabled/build.sbt
@@ -2,7 +2,7 @@ name := "start-script-disabled"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-startScriptLocation := ""
+rpStartScriptLocation := ""
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/start-script-enabled/build.sbt
@@ -2,9 +2,9 @@ name := "start-script-enabled"
 scalaVersion := "2.12.4"
 enablePlugins(SbtReactiveAppPlugin)
 
-startScriptLocation := "/my-rp-entry"
+rpStartScriptLocation := "/my-rp-entry"
 
-applications += "cleanup" -> Seq("bin/test")
+rpApplications += "cleanup" -> Seq("bin/test")
 
 TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.1-SNAPSHOT"
+version in ThisBuild := "1.5.0-SNAPSHOT"


### PR DESCRIPTION
Deprecated the old keys.

Fixes #130

This takes the most-change approach, where the old runtime kebab-cased keys aren't persevered and non-prefixed keys are prefixed.

However a more gentle approach can be taken instead, if preferred.

Review by @eed3si9n.