### PR TITLE
Unleash scripted across sbt versions

### DIFF
--- a/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/akka-cluster-endpoints/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.5

--- a/src/sbt-test/sbt-reactive-app/detection/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/detection/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/sbt-reactive-app/export-annotations/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/export-annotations/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.6

--- a/src/sbt-test/sbt-reactive-app/lagom-1.4-endpoints/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.4-endpoints/project/build.properties
@@ -1,1 +1,0 @@
-../../lagom-1.5-endpoints/project/build.properties

--- a/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/sbt-reactive-app/prepend-rp-conf-disabled/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/prepend-rp-conf-disabled/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.4

--- a/src/sbt-test/sbt-reactive-app/prepend-rp-conf/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/prepend-rp-conf/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.4

--- a/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/run-as-user-group-uid-gid/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.4

--- a/src/sbt-test/sbt-reactive-app/run-as-user/project/build.properties
+++ b/src/sbt-test/sbt-reactive-app/run-as-user/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.4


### PR DESCRIPTION
By deleting the build.properties files these tests are properly tested
across sbt versions, like .travis.yml is configured.