### PR TITLE
Add support for base docker images based on deb/rpm

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -105,9 +105,26 @@ trait SbtReactiveAppKeys {
   val akkaManagementEndpointName = SettingKey[String]("rp-akka-management-endpoint-name")
 
   /**
-   * Defines packages to install on top of the base alpine image.
+   * Defines packages to install on top of the base docker image.
    */
+  val userPackages = SettingKey[Seq[String]]("rp-user-packages")
+
+  @deprecated("Use userPackages instead", "1.4.1")
   val alpinePackages = SettingKey[Seq[String]]("rp-alpine-packages")
+
+  /**
+   * This setting will include by default "bash", plus the user-defined packages in `userPackages`.
+   * It can be overridden if necessary, for instance if the bash utility is defined in a package that
+   * has a different name in the specific docker base image that was selected.
+   */
+  val allDockerPackages = SettingKey[Seq[String]]("rp-all-docker-packages")
+
+  /**
+   * Defines the package installation mechanism used by the base image defined by dockerBaseImage.
+   * The default is "apk", to match the default Alpine dockerBaseImage;
+   * "apt-get", "apt", "dnf", and "yum" are other valid values.
+   */
+  val packagingFormat = SettingKey[String]("rp-packaging-format")
 
   /**
    * Defines the available applications. This is a list of appName -> appArgs. The operator can specify alternate
@@ -309,9 +326,4 @@ trait SbtReactiveAppKeys {
 
   private[sbtreactiveapp] val reactiveLibStatusProject = SettingKey[(String, Boolean)]("rp-reactive-lib-status-project")
 
-  /**
-   * Defines alpine packages that are installed (and required) by this plugin. This is combined with the user-defined
-   * packages (`alpinePackages`).
-   */
-  private[sbtreactiveapp] val requiredAlpinePackages = SettingKey[Seq[String]]("rp-required-alpine-packages")
 }

--- a/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/alpine-packages/build.sbt
@@ -8,7 +8,7 @@ TaskKey[Unit]("check") := {
   val outputDir = (stage in Docker).value
   val contents = IO.readLines(outputDir / "Dockerfile")
   val lines = Seq(
-    """RUN /sbin/apk add --no-cache bash coreutils""")
+    """RUN /sbin/apk add --no-cache coreutils bash""")
 
   lines.foreach { line =>
     if (!contents.contains(line)) {


### PR DESCRIPTION
With this pull request, the `requiredAlpinePackages` and `alpinePackages` settings are deprecated in favor of the new settings `userPackages` and `allDockerPackages`, while retaining compatibility. The new setting `packagingFormat` is introduced, with a default value of "apk", in order to use the Alpine package manager as default. The setting can be changed to apt, apt-get, dnf, or yum, in order to use the package manager more suitable to a different docker base image selected by `dockerBaseImage`.

Resolves https://github.com/lightbend/sbt-reactive-app/issues/147
