### PR TITLE
Handle non-defined rpDockerPublish

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -37,7 +37,7 @@ object SbtReactiveAppPluginAll extends AutoPlugin {
       publish in docker.DockerPlugin.autoImport.Docker := {
         Def.taskDyn {
           if (dockerUsername.?.value.isDefined || dockerRepository.?.value.isDefined)
-            Def.task(rpDockerPublish.value)
+            Def.task(rpDockerPublish.?.value.getOrElse(()))
           else Def.task(())
         }.value
       })


### PR DESCRIPTION
In ff298c8dd8d4bac3385f5e0e0107378ad0457563 I tried to more accurately
model what I assumed was the intended behaviour, by wrapping the
invocation of rpDockerPublish in a Task.  In doing so, however, I
dropped the .?, which originally allowed for rpDockerPublish to be
undefined.  This caused a regression.

At this point I'm not sure why SbtReactiveAppPluginAll even exists.  Why
not redefine publish in Docker in SbtReactiveAppPlugin, where
rpDockerPublish is actually defined?  I went with the smaller change.