### PR TITLE
Update helm repo reference

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/helm.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/helm.scala
@@ -28,7 +28,7 @@ object helm {
       run(logStdErr = Some(logger), logStdOut = Some(logger))("helm", "init", "--service-account", serviceAccount))
 
     runSuccess("helm repo add failed")(
-      run(logStdErr = Some(logger), logStdOut = Some(logger))("helm", "repo", "add", "lightbend-helm-charts", "https://lightbend.github.io/helm-charts"))
+      run(logStdErr = Some(logger), logStdOut = Some(logger))("helm", "repo", "add", "lightbend-helm-charts", "https://repo.lightbend.com/helm-charts"))
 
     runSuccess("helm repo update")(
       run(logStdErr = Some(logger), logStdOut = Some(logger))("helm", "repo", "update"))


### PR DESCRIPTION
The default location for the Lightbend helm-charts repo has moved to `https://repo.lightbend.com/helm-charts` and the old location (`https://lightbend.github.io/helm-charts`) is deprecated (and may go away at some point).  This change moves sbt-reactive-app to use the new location.

Fixes #160