### PR TITLE
Tiller RBAC setup fails cause of type in kubectl cmd

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/kubectl.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/kubectl.scala
@@ -28,13 +28,13 @@ object kubectl {
     runSuccess("kubectl is not installed")(run()("kubectl", "version"))
 
   def setupHelmRBAC(logger: Logger, systemNamespace: String): Unit = {
-    val (c1, _, _) = run()("kubectl", "-n", systemNamespace, "create", "sa", "tiller")
-    if (c1 != 0) {
+    val (c1, _, err) = run()("kubectl", "-n", systemNamespace, "create", "sa", "tiller")
+    if (c1 != 0 && !err.exists(_.contains("AlreadyExists"))) {
       sys.error(s"failed to create tiller service account [$c1]")
     }
 
     val (c2, _, _) = run()("kubectl", "create", "clusterrolebinding",
-      "tiller", "--closterrole", "cluster-admin", s"--serviceaccount=$systemNamespace:tiller")
+      "tiller", "--clusterrole", "cluster-admin", s"--serviceaccount=$systemNamespace:tiller")
     if (c2 != 0) {
       sys.error(s"failed to create tiller cluster role binding [$c2]")
     }


### PR DESCRIPTION
`kubectl` command has typo, this pull requests fixes this typo, also added check if service account already exists to prevent error from blocking tiller setup.

Fixes #154