### PR TITLE
Print YAML resources when kubectl crashes

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/kubectl.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/cmd/kubectl.scala
@@ -50,7 +50,8 @@ object kubectl {
       run(input = Some(yaml), logStdErr = Some(logger), logStdOut = Some(logger))("kubectl", "apply", "-f", "-")
 
     if (code != 0) {
-      sys.error(s"rp apply failed [$code]")
+      logger.error(s"kubectl apply failed with YAML resources:\n$yaml")
+      sys.error(s"kubectl apply failed [$code]")
     }
   }
 


### PR DESCRIPTION
Print YAML resources when kubectl crashes

Also, fixes the error message (which referred to `rp` instead of `kubectl`).

Closes #170