### PR TITLE
Fixes blank rp-application

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -271,15 +271,16 @@ case object BasicApp extends DeployableApp {
 
         val allApplicationConfFiles = unmanagedTransitive.value.flatten.toList
         val unmanagedConfigName = rpPrependRpConf.value
+        val cp = (dependencyClasspath in Compile).value
         if (unmanagedConfigName.isEmpty) Nil
         else {
           // 1. make the file under cache/sbt-reactive-app.
           // 2. compare its SHA1 against cache/sbt-reactive-app-inputs
           IO.write(tempFile, magic.Build.extractRpToolingConf(
             Vector(ToolingConfig),
-            (dependencyClasspath in Compile).value,
+            cp,
             allApplicationConfFiles.nonEmpty,
-            unmanagedConfigName).getOrElse(""))
+            unmanagedConfigName))
           cachedCopyFile(FileInfo.hash(tempFile))
           Seq(outFile)
         }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Build.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Build.scala
@@ -39,7 +39,7 @@ object Build {
     managedConfigNames: Seq[String],
     dependencyClasspath: Seq[Attributed[File]],
     prependInclude: Boolean,
-    unmanagedConfigName: String): Option[String] = {
+    unmanagedConfigName: String): String = {
     val dependencyClassLoader = new java.net.URLClassLoader(dependencyClasspath.files.map(_.toURI.toURL).toArray)
 
     val managedConfigs: List[URL] =
@@ -47,20 +47,14 @@ object Build {
         .flatMap(dependencyClassLoader.findResources(_).asScala)
         .toList
 
-    managedConfigs match {
-      case Nil => None
-      case _ =>
-        Some(
-          annotate(
-            prependInclude,
-            unmanagedConfigName,
-            managedConfigs
-              .foldLeft(Seq.empty[String]) {
-                case (accum, conf) =>
-                  accum :+ withHeader(conf.toString, IO.readLinesURL(conf).mkString(IO.Newline))
-              }
-              .mkString(IO.Newline)))
-    }
+    annotate(
+      prependInclude,
+      unmanagedConfigName,
+      (managedConfigs
+        .foldLeft(Seq.empty[String]) {
+          case (accum, conf) =>
+            accum :+ withHeader(conf.toString, IO.readLinesURL(conf).mkString(IO.Newline))
+        }).mkString(IO.Newline))
   }
 
   def makeConfig(dependencyClasspath: Seq[File]): Config = {

--- a/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/play-endpoints/build.sbt
@@ -36,4 +36,9 @@ TaskKey[Unit]("check") := {
                    |$contents""")
     }
   }
+
+  val rpApplicationConf = resourceManaged.value / "main" / "sbt-reactive-app" / "rp-application.conf"
+  val confContents = augmentString(IO.read(rpApplicationConf)).lines.toList
+  assert(confContents contains """include "application.conf"""", confContents.toString)
+
 }


### PR DESCRIPTION
Fixes #171

When no rp-tooling.conf is included rp-application becomes blank, which surfaces as Play not having secrets set etc because application.conf gets ignored.

/cc @lightbend/play-team 
