### PR TITLE
Fix http port detection for Lagom

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -95,11 +95,14 @@ sealed trait LagomApp extends App {
         val ingressHosts = rpHttpIngressHosts.value
         val ingressPaths = rpHttpIngressPaths.value
         val endpointName = name.value
+        val config = rpApplicationConfig.value
+        val servicePort = config.getInt("play.server.http.port")
 
         val magicEndpoints =
           magic.Lagom.endpoints(
             ((managedClasspath in ApiTools).value ++ (fullClasspath in Compile).value).toVector,
             scalaInstance.value.loader,
+            servicePort,
             ingressPorts.toVector,
             ingressHosts.toVector,
             ingressPaths.toVector)
@@ -110,9 +113,9 @@ sealed trait LagomApp extends App {
         if (magicEndpoints.nonEmpty)
           magicEndpoints
         else if (ingressPaths.nonEmpty)
-          Vector(HttpEndpoint(endpointName, HttpIngress(ingressPorts, ingressHosts, ingressPaths)))
+          Vector(HttpEndpoint(endpointName, servicePort, HttpIngress(ingressPorts, ingressHosts, ingressPaths)))
         else
-          Vector(HttpEndpoint(endpointName))
+          Vector(HttpEndpoint(endpointName, servicePort))
       },
 
       // Note: Play & Lagom need their endpoints defined first (see play-http-binding)
@@ -210,7 +213,7 @@ case object BasicApp extends DeployableApp {
       rpAkkaManagementEndpointName := "management",
       rpHttpIngressHosts := Seq.empty,
       rpHttpIngressPaths := Seq.empty,
-      rpHttpIngressPorts := Seq(80, 443))
+      rpHttpIngressPorts := Seq.empty)
 
   def buildSettings: Seq[Setting[_]] =
     Vector(

--- a/src/sbt-test/sbt-reactive-app/lagom-1.4-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.4-endpoints/build.sbt
@@ -27,20 +27,19 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-lagom",
-    httpIngressPorts := scala.collection.immutable.Seq(9000),
     libraryDependencies += lagomScaladslCluster,
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.read(outputDir / "Dockerfile")
       val expectedLines = Seq(
-        """com.lightbend.rp.endpoints.0.protocol="http"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
         """com.lightbend.rp.endpoints.0.name="http"""",
+        """com.lightbend.rp.endpoints.0.protocol="http"""",
+        """com.lightbend.rp.endpoints.0.port="9000"""",
+        """com.lightbend.rp.endpoints.0.ingress.0.paths.0="/api/hello"""",
+        """com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
         """com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="true"""",
         """com.lightbend.rp.app-type="lagom"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
         """com.lightbend.rp.app-name="hello"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.paths.0="/api/hello"""",
         """com.lightbend.rp.modules.common.enabled="true"""",
         """com.lightbend.rp.modules.secrets.enabled="false"""",
         """com.lightbend.rp.modules.service-discovery.enabled="true"""",
@@ -65,7 +64,6 @@ lazy val `echo-impl` = (project in file("echo-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "echo-lagom",
-    httpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.readLines(outputDir / "Dockerfile")

--- a/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/build.sbt
@@ -26,19 +26,18 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "hello-lagom",
-    rpHttpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.read(outputDir / "Dockerfile")
       val expectedLines = Seq(
         """com.lightbend.rp.endpoints.0.protocol="http"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.ingress-ports.0="9000"""",
+        """com.lightbend.rp.endpoints.0.port="9000"""",
         """com.lightbend.rp.endpoints.0.name="http"""",
+        """com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
+        """com.lightbend.rp.endpoints.0.ingress.0.paths.0="/api/hello"""",
         """com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled="false"""",
         """com.lightbend.rp.app-type="lagom"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.type="http"""",
         """com.lightbend.rp.app-name="hello"""",
-        """com.lightbend.rp.endpoints.0.ingress.0.paths.0="/api/hello"""",
         """com.lightbend.rp.modules.common.enabled="true"""",
         """com.lightbend.rp.modules.secrets.enabled="false"""",
         """com.lightbend.rp.modules.service-discovery.enabled="true""""
@@ -62,7 +61,6 @@ lazy val `echo-impl` = (project in file("echo-impl"))
   .enablePlugins(LagomScala, SbtReactiveAppPlugin)
   .settings(
     packageName in Docker := "echo-lagom",
-    rpHttpIngressPorts := scala.collection.immutable.Seq(9000),
     check := {
       val outputDir = (stage in Docker).value
       val contents = IO.readLines(outputDir / "Dockerfile")


### PR DESCRIPTION
Fixes https://github.com/lightbend/reactive-cli/issues/205

#164 implemented endpoint port probing using Lightbend Config.
It turns out there's a seprate http endpoint creation going on for Lagom, which I missed.

/cc @lightbend/play-team 
