### PR TITLE
preliminary Lagom 1.5 compatibility

### DIFF
--- a/script/install-minikube.sh
+++ b/script/install-minikube.sh
@@ -10,6 +10,8 @@ curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.
 # Download minikube.
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 sudo minikube start --vm-driver=none --kubernetes-version=v1.10.0
+sudo chown -R travis /home/travis/.minikube/
+
 # Fix the kubectl context, as it's often stale.
 minikube update-context
 # Wait for Kubernetes to be up and ready.

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppKeys.scala
@@ -195,6 +195,12 @@ trait SbtReactiveAppKeys {
    */
   val rpEnableAkkaClusterBootstrap = taskKey[Boolean]("Include Akka Cluster Bootstrapping. By default, included if a Lagom persistence module is defined.")
 
+  val rpDetectedLagomJavaVersion = settingKey[Option[String]]("Detected Lagom Java version.")
+  val rpDetectedLagomScalaVersion = settingKey[Option[String]]("Detected Lagom Scala version.")
+
+  val rpLagomJavaExtras = settingKey[Seq[ModuleID]]("Extra modules to inject into Lagom Java application.")
+  val rpLagomScalaExtras = settingKey[Seq[ModuleID]]("Extra modules to inject into Lagom Scala application.")
+
   /**
    * Enables Akka Management (reactive-lib).
    *

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Lagom.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/magic/Lagom.scala
@@ -58,6 +58,20 @@ object Lagom {
         d.name.contains("-persistence") || d.name.contains("-pubsub") || d.name.contains("-cluster")))
   }
 
+  def detectedLagomJavaVersion(libraryDependencies: Seq[ModuleID]): Option[String] = {
+    libraryDependencies.find(d =>
+      d.organization == "com.lightbend.lagom" && (
+        d.name.contains("lagom-javadsl-server")))
+      .map(_.revision)
+  }
+
+  def detectedLagomScalaVersion(libraryDependencies: Seq[ModuleID]): Option[String] = {
+    libraryDependencies.find(d =>
+      d.organization == "com.lightbend.lagom" && (
+        d.name.contains("lagom-scaladsl-server")))
+      .map(_.revision)
+  }
+
   def lagomJavaPlugin(classLoader: ClassLoader): Try[AutoPlugin] =
     withContextClassloader(classLoader) { loader =>
       getSingletonObject[AutoPlugin](loader, "com.lightbend.lagom.sbt.LagomJava$")

--- a/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/project/plugins.sbt
+++ b/src/sbt-test/sbt-reactive-app/lagom-1.5-endpoints/project/plugins.sbt
@@ -4,5 +4,5 @@ sys.props.get("plugin.version") match {
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
 
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M4")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-RC2")
 


### PR DESCRIPTION
/cc @lightbend/play-team 

This removes all reactive-lib injections when Lagom 1.5 is detected, and inject the following "extras"  instead:

```scala
      rpLagomJavaExtras := Vector(
        "com.lightbend.lagom" %% "lagom-javadsl-akka-discovery-service-locator" % "1.0.0",
        "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "1.0.0"),
      rpLagomScalaExtras := Vector(
        "com.lightbend.lagom" %% "lagom-scaladsl-akka-discovery-service-locator" % "1.0.0",
        "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "1.0.0"),
```
